### PR TITLE
Connect CSV data to timeline and tracker

### DIFF
--- a/Harvard/Timeline-form.html
+++ b/Harvard/Timeline-form.html
@@ -6,50 +6,96 @@
   <title>Add Timeline Event</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <script src="assets/js/data-loader.js"></script>
   <script>
     const SHEET_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
+    const PLACEHOLDER_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
+
+    function shouldSubmitToSheet() {
+      return Boolean(SHEET_URL && SHEET_URL !== PLACEHOLDER_URL);
+    }
+
+    function buildBasePayload(formValues) {
+      const payload = new URLSearchParams();
+      payload.append("sheet", "Timeline");
+      payload.append("eventName", formValues.eventName);
+      payload.append("day", formValues.day);
+      payload.append("month", formValues.month);
+      payload.append("year", formValues.year);
+      payload.append("summary", formValues.summary);
+      payload.append("link", formValues.link);
+      return payload;
+    }
+
+    function storeSubmission(values) {
+      DataLoader.saveTimelineSubmission({
+        title: values.eventName,
+        summary: values.summary,
+        month: values.month,
+        day: values.day,
+        year: values.year,
+        link: values.link,
+        imageData: values.imageData || ''
+      });
+    }
+
+    function readFileAsDataURL(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(file);
+      });
+    }
+
+    async function submitToSheet(payload) {
+      if (!shouldSubmitToSheet()) {
+        return;
+      }
+      await fetch(SHEET_URL, { method: "POST", body: payload });
+    }
 
     async function handleSubmit(e) {
       e.preventDefault();
       const form = document.getElementById("timelineForm");
       const fileInput = document.getElementById("file");
 
-      let fileData = "";
-      let filetype = "";
-      let filename = "";
+      const formValues = {
+        eventName: form.eventName.value.trim(),
+        day: form.day.value.trim(),
+        month: form.month.value.trim(),
+        year: form.year.value.trim(),
+        summary: form.summary.value.trim(),
+        link: form.link.value.trim()
+      };
 
+      let imageDataUrl = '';
       if (fileInput.files.length > 0) {
-        const file = fileInput.files[0];
-        filename = file.name;
-        filetype = file.type;
-        const reader = new FileReader();
-        reader.onloadend = async function() {
-          fileData = btoa(reader.result);
+        try {
+          imageDataUrl = await readFileAsDataURL(fileInput.files[0]);
+        } catch (error) {
+          console.warn('Unable to read uploaded image.', error);
+        }
+      }
 
-          let formData = new URLSearchParams();
-          formData.append("sheet","Timeline");
-          formData.append("eventName", form.eventName.value);
-          formData.append("day", form.day.value);
-          formData.append("month", form.month.value);
-          formData.append("year", form.year.value);
-          formData.append("summary", form.summary.value);
-          formData.append("link", form.link.value);
-          formData.append("file", fileData);
-          formData.append("filename", filename);
-          formData.append("filetype", filetype);
+      formValues.imageData = imageDataUrl;
+      storeSubmission(formValues);
 
-          await fetch(SHEET_URL, { method: "POST", body: formData });
-          alert("Event submitted!");
-          form.reset();
-        };
-        reader.readAsBinaryString(file);
-      } else {
-        // No file, just submit text data
-        let formData = new URLSearchParams(new FormData(form));
-        formData.append("sheet","Timeline");
+      const payload = buildBasePayload(formValues);
+      if (imageDataUrl && fileInput.files.length > 0) {
+        const base64Data = imageDataUrl.split(',')[1] || '';
+        payload.append('file', base64Data);
+        payload.append('filename', fileInput.files[0].name);
+        payload.append('filetype', fileInput.files[0].type);
+      }
 
-        await fetch(SHEET_URL, { method: "POST", body: formData });
-        alert("Event submitted (no image)!");
+      try {
+        await submitToSheet(payload);
+        alert('Event submitted! Refresh the timeline to see your update.');
+      } catch (error) {
+        console.error('Sheet submission failed', error);
+        alert('Event saved locally but could not be submitted to the spreadsheet. Please try again later.');
+      } finally {
         form.reset();
       }
     }

--- a/Harvard/Timeline.html
+++ b/Harvard/Timeline.html
@@ -218,87 +218,17 @@
 </div>
 
 <div class="p-2">
-<ul class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4">
-    <li class="list-group-item">Item 1</li>
-    <li class="list-group-item">Item 2</li>
-    <li class="list-group-item">Item 3</li>
-    <li class="list-group-item">Item 4</li>
-    <li class="list-group-item">Item 5</li>
-</ul>
+  <ul class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4" id="timelineTypeList">
+    <!-- Populated dynamically -->
+  </ul>
 </div>
 
 <div class="container mb-4">
+  <div id="timelineMessage" class="alert alert-info d-none" role="alert"></div>
   <div class="row">
     <!-- Timeline on the left -->
     <div class="col-lg-9 col-md-8">
-      <div id="timeline">
-        <!-- Event Row -->
-        <div class="row timeline-row" data-year="2025" data-month="09" data-type="conference">
-          <div class="col-2 fw-bold">2025</div>
-          <div class="col-2 text-center">
-            <div>September</div>
-            <div class="fw-bold fs-5">17</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Tech Conference</h2>
-              <p class="mb-0">A brief description of the event.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Tech Conference</h2>
-                  <p>
-                    A longer paragraph about the event. Details about speakers, 
-                    location, and significance go here. This section will scroll 
-                    if content is longer than the allocated space.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="event image.jpg" alt="Event image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Another Event -->
-        <div class="row timeline-row" data-year="2024" data-month="02" data-type="project">
-          <div class="col-2 fw-bold">2024</div>
-          <div class="col-2 text-center">
-            <div>February</div>
-            <div class="fw-bold fs-5">12</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Website Launch</h2>
-              <p class="mb-0">The new company site goes live.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Website Launch</h2>
-                  <p>
-                    Details about the project, the team involved, and future goals. 
-                    If this text is long, it will also scroll independently.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="https://via.placeholder.com/600x400" alt="Project image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      <div id="timeline" class="d-flex flex-column gap-4"></div>
     </div>
 
     <!-- Filters on the right -->
@@ -306,14 +236,9 @@
       <div class="d-flex flex-column align-items-end gap-3">
         <select class="form-select w-auto" id="filterYear">
           <option value="">All Years</option>
-          <option value="2024">2024</option>
-          <option value="2025">2025</option>
         </select>
         <select class="form-select w-auto" id="filterMonth">
           <option value="">All Months</option>
-          <option value="01">January</option>
-          <option value="02">February</option>
-          <option value="09">September</option>
         </select>
       </div>
     </div>
@@ -328,40 +253,9 @@
   <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
 </footer>
 
-<script>
-  // Filtering logic
-  const filters = { year: '', month: '', type: '' };
-
-  function applyFilters() {
-    document.querySelectorAll('#timeline .timeline-row').forEach(row => {
-      const match =
-        (!filters.year || row.dataset.year === filters.year) &&
-        (!filters.month || row.dataset.month === filters.month) &&
-        (!filters.type || row.dataset.type === filters.type);
-      row.style.display = match ? '' : 'none';
-    });
-  }
-
-  document.getElementById('filterYear').addEventListener('change', e => {
-    filters.year = e.target.value;
-    applyFilters();
-  });
-  document.getElementById('filterMonth').addEventListener('change', e => {
-    filters.month = e.target.value;
-    applyFilters();
-  });
-
-  // Toggle expand/collapse on click
-  document.querySelectorAll('.timeline-event').forEach(eventCol => {
-    eventCol.addEventListener('click', e => {
-      const row = eventCol.closest('.timeline-row');
-      document.querySelectorAll('.timeline-row.active').forEach(openRow => {
-        if (openRow !== row) openRow.classList.remove('active');
-      });
-      row.classList.toggle('active');
-    });
-  });
-</script>
+<script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+<script src="assets/js/data-loader.js"></script>
+<script src="assets/js/timeline.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Harvard/Tracker-form.html
+++ b/Harvard/Tracker-form.html
@@ -6,17 +6,74 @@
   <title>Add Recommendation</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <script src="assets/js/data-loader.js"></script>
   <script>
     const SHEET_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
+    const PLACEHOLDER_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
+
+    function shouldSubmitToSheet() {
+      return Boolean(SHEET_URL && SHEET_URL !== PLACEHOLDER_URL);
+    }
+
+    function buildPayload(values) {
+      const payload = new URLSearchParams();
+      payload.append('sheet', 'Recommendations');
+      payload.append('title', values.title);
+      payload.append('date', values.date);
+      payload.append('organization', values.organization);
+      payload.append('type', values.type);
+      payload.append('status', values.status);
+      payload.append('actionDate', values.actionDate);
+      payload.append('description', values.description);
+      return payload;
+    }
+
+    function storeSubmission(values) {
+      DataLoader.saveTrackerSubmission({
+        title: values.title,
+        date: values.date,
+        organization: values.organization,
+        type: values.type,
+        status: values.status,
+        actionDate: values.actionDate,
+        description: values.description
+      });
+    }
+
+    async function submitToSheet(payload) {
+      if (!shouldSubmitToSheet()) {
+        return;
+      }
+      await fetch(SHEET_URL, { method: 'POST', body: payload });
+    }
 
     async function handleSubmit(e) {
       e.preventDefault();
-      let formData = new FormData(document.getElementById("recForm"));
-      formData.append("sheet","Recommendations");
+      const form = document.getElementById('recForm');
 
-      await fetch(SHEET_URL, { method: "POST", body: formData });
-      alert("Recommendation submitted!");
-      document.getElementById("recForm").reset();
+      const values = {
+        title: form.title.value.trim(),
+        date: form.date.value,
+        organization: form.organization.value.trim(),
+        type: form.type.value.trim(),
+        status: form.status.value.trim(),
+        actionDate: form.actionDate.value,
+        description: form.description.value.trim()
+      };
+
+      storeSubmission(values);
+
+      const payload = buildPayload(values);
+
+      try {
+        await submitToSheet(payload);
+        alert('Recommendation submitted! Refresh the tracker to see your update.');
+      } catch (error) {
+        console.error('Sheet submission failed', error);
+        alert('Recommendation saved locally but could not be submitted to the spreadsheet. Please try again later.');
+      } finally {
+        form.reset();
+      }
     }
   </script>
     <style>

--- a/Harvard/Tracker.html
+++ b/Harvard/Tracker.html
@@ -127,6 +127,7 @@
   <!-- Tracker -->
   <div class="container my-5">
     <h2>Recommendations Tracker</h2>
+    <div id="trackerMessage" class="alert alert-info d-none" role="alert"></div>
     <div class="table-responsive">
       <table class="table" id="accordionData">
         <thead>
@@ -152,65 +153,9 @@
     <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
   </footer>
 
-  <script>
-    async function loadData() {
-      // Fake test data (replace with fetch)
-      const data = [
-        { date: "April 1, 2023", title: "Recommendation 1", status: "Resolved", organization: "Org A", type: "Type A", description: "Fixed issue", timestamp: "2023-04-01" },
-        { date: "April 2, 2023", title: "Recommendation 2", status: "In Progress", organization: "Org B", type: "Type B", description: "Still working", timestamp: "2023-04-02" },
-        { date: "April 3, 2023", title: "Recommendation 3", status: "Not Taken", organization: "Org C", type: "Type C", description: "Not acted upon", timestamp: "2023-04-03" }
-      ];
-
-      const container = document.querySelector("#accordionData tbody");
-      container.innerHTML = "";
-
-      data.forEach((row, i) => {
-        let statusClass = "";
-        if (row.status === "Resolved") statusClass = "status-resolved";
-        else if (row.status === "In Progress") statusClass = "status-progress";
-        else if (row.status === "Not Taken") statusClass = "status-not-taken";
-
-        container.innerHTML += `
-          <tr class="accordion-toggle collapsed ${statusClass}"
-              role="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#collapse${i}"
-              aria-expanded="false"
-              aria-controls="collapse${i}">
-            <td>${row.date}</td>
-            <td>${row.title}</td>
-            <td>${row.status}</td>
-            <td class="expand-button">
-              <span class="toggle-icon"><i class="bi bi-chevron-down"></i></span>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="4">
-              <div id="collapse${i}" class="collapse accordion-body p-3" data-bs-parent="#accordionData">
-                <div class="row"><div class="col-2">Organization</div><div class="col-6">${row.organization}</div></div>
-                <div class="row"><div class="col-2">Type</div><div class="col-6">${row.type}</div></div>
-                <div class="row"><div class="col-2">Description</div><div class="col-6">${row.description}</div></div>
-                <small><em>Submitted: ${row.timestamp}</em></small>
-              </div>
-            </td>
-          </tr>`;
-      });
-    }
-
-    document.addEventListener("DOMContentLoaded", () => {
-      // Load table
-      loadData();
-
-      // Hook the offcanvas events to flip the toggler icon
-      const offcanvas = document.getElementById('offcanvasNav');
-      const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
-
-      if (offcanvas && toggler) {
-        offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
-        offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
-      }
-    });
-  </script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="assets/js/data-loader.js"></script>
+  <script src="assets/js/tracker.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/Harvard/assets/js/data-loader.js
+++ b/Harvard/assets/js/data-loader.js
@@ -1,0 +1,470 @@
+(function (window) {
+  const CSV_URL = 'Content Tracker _ Timeline - Timeline of Events.csv';
+  const STORAGE_KEYS = {
+    timeline: 'harvardTimelineCustomEvents',
+    tracker: 'harvardTrackerCustomItems'
+  };
+  const monthNames = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+  ];
+
+  let cachedCsvRecords = null;
+  let csvLoadPromise = null;
+
+  function pad(value) {
+    return String(value).padStart(2, '0');
+  }
+
+  function readStorage(key) {
+    try {
+      const raw = window.localStorage ? window.localStorage.getItem(key) : null;
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('Unable to read from storage', error);
+      return [];
+    }
+  }
+
+  function writeStorage(key, value) {
+    try {
+      if (!window.localStorage) {
+        return;
+      }
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn('Unable to write to storage', error);
+    }
+  }
+
+  function normaliseSource(value) {
+    if (!value) {
+      return { link: '', label: '' };
+    }
+    const trimmed = String(value).trim();
+    if (/^https?:\/\//i.test(trimmed)) {
+      try {
+        const url = new URL(trimmed);
+        return { link: trimmed, label: url.hostname.replace(/^www\./, '') };
+      } catch (error) {
+        return { link: trimmed, label: trimmed };
+      }
+    }
+    return { link: '', label: trimmed };
+  }
+
+  function createSortKey(year, month, day, fallback) {
+    if (year && month) {
+      const resolvedDay = day || 1;
+      return Number(`${year}${pad(month)}${pad(resolvedDay)}`);
+    }
+    if (fallback) {
+      const timestamp = Date.parse(fallback);
+      if (!Number.isNaN(timestamp)) {
+        return timestamp;
+      }
+    }
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  function parseDateParts(yearString, dateString) {
+    const result = {
+      year: null,
+      yearDisplay: '',
+      month: null,
+      monthPadded: '',
+      monthName: '',
+      day: null,
+      displayDate: '',
+      dateText: '',
+      sortKey: Number.MAX_SAFE_INTEGER,
+      raw: dateString || ''
+    };
+
+    const baseYear = parseInt(yearString, 10);
+    if (!Number.isNaN(baseYear)) {
+      result.year = baseYear;
+      result.yearDisplay = String(baseYear);
+    } else if (yearString) {
+      result.yearDisplay = String(yearString);
+    }
+
+    if (!dateString) {
+      if (result.year) {
+        result.sortKey = Number(`${result.year}0000`);
+      }
+      return result;
+    }
+
+    const trimmed = String(dateString).trim();
+    if (!trimmed) {
+      if (result.year) {
+        result.sortKey = Number(`${result.year}0000`);
+      }
+      return result;
+    }
+
+    const numericMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?$/);
+    if (numericMatch) {
+      const month = parseInt(numericMatch[1], 10);
+      const day = parseInt(numericMatch[2], 10);
+      let parsedYear = numericMatch[3] ? parseInt(numericMatch[3], 10) : null;
+      if (!Number.isNaN(parsedYear) && parsedYear !== null && numericMatch[3].length === 2) {
+        const centuryBase = result.year && result.year >= 1900 ? Math.floor(result.year / 100) * 100 : 2000;
+        parsedYear = centuryBase + parsedYear;
+      }
+      if (Number.isNaN(parsedYear)) {
+        parsedYear = null;
+      }
+      const finalYear = parsedYear || result.year || null;
+      if (finalYear) {
+        result.year = finalYear;
+        result.yearDisplay = String(finalYear);
+      }
+      result.month = Number.isNaN(month) ? null : month;
+      result.day = Number.isNaN(day) ? null : day;
+      if (result.month) {
+        result.monthName = monthNames[result.month - 1] || '';
+        result.monthPadded = pad(result.month);
+      }
+      if (result.monthName && result.day) {
+        result.displayDate = `${result.monthName} ${result.day}`;
+        result.dateText = finalYear ? `${result.displayDate}, ${finalYear}` : result.displayDate;
+      } else if (result.monthName) {
+        result.displayDate = result.monthName;
+        result.dateText = result.monthName;
+      } else {
+        result.displayDate = trimmed;
+        result.dateText = trimmed;
+      }
+      result.sortKey = createSortKey(result.year, result.month, result.day);
+      return result;
+    }
+
+    const candidate = new Date(trimmed + (result.year ? ` ${result.year}` : ''));
+    if (!Number.isNaN(candidate.getTime())) {
+      result.year = candidate.getFullYear();
+      result.yearDisplay = String(result.year);
+      result.month = candidate.getMonth() + 1;
+      result.monthPadded = pad(result.month);
+      result.day = candidate.getDate();
+      result.monthName = monthNames[result.month - 1] || '';
+      result.displayDate = result.monthName
+        ? `${result.monthName} ${result.day}`
+        : candidate.toLocaleDateString('en-US');
+      result.dateText = result.displayDate;
+      result.sortKey = createSortKey(result.year, result.month, result.day);
+      return result;
+    }
+
+    result.displayDate = trimmed;
+    result.dateText = trimmed;
+    if (result.year) {
+      result.sortKey = Number(`${result.year}0000`);
+    }
+    return result;
+  }
+
+  function parseCsvRecords(rows) {
+    const records = [];
+    let currentYear = '';
+    rows.forEach((row, index) => {
+      if (!Array.isArray(row) || row.length === 0) {
+        return;
+      }
+      const [rawYear = '', rawDate = '', rawEvent = '', rawSource = '', rawType = ''] = row;
+      if (index === 0 && String(rawDate).toLowerCase().includes('date')) {
+        return;
+      }
+      const yearCell = String(rawYear || '').trim();
+      const dateCell = String(rawDate || '').trim();
+      const eventCell = String(rawEvent || '').trim();
+      const sourceCell = String(rawSource || '').trim();
+      const typeCell = String(rawType || '').trim();
+
+      if (yearCell) {
+        currentYear = yearCell;
+      }
+      const effectiveYear = yearCell || currentYear;
+
+      if (!eventCell && !dateCell) {
+        return;
+      }
+
+      const parsedDate = parseDateParts(effectiveYear, dateCell);
+      const sourceInfo = normaliseSource(sourceCell);
+
+      records.push({
+        index,
+        yearString: effectiveYear,
+        dateRaw: dateCell,
+        event: eventCell,
+        source: sourceCell,
+        sourceLink: sourceInfo.link,
+        sourceLabel: sourceInfo.label,
+        type: typeCell,
+        parsedDate
+      });
+    });
+    return records;
+  }
+
+  function getCsvRecords() {
+    if (cachedCsvRecords) {
+      return Promise.resolve(cachedCsvRecords);
+    }
+    if (csvLoadPromise) {
+      return csvLoadPromise;
+    }
+    csvLoadPromise = new Promise((resolve, reject) => {
+      if (typeof window.Papa === 'undefined') {
+        reject(new Error('Papa Parse library is required to load CSV data.'));
+        csvLoadPromise = null;
+        return;
+      }
+      window.Papa.parse(CSV_URL, {
+        download: true,
+        skipEmptyLines: false,
+        complete: (results) => {
+          try {
+            cachedCsvRecords = parseCsvRecords(results.data || []);
+            resolve(cachedCsvRecords);
+          } catch (error) {
+            reject(error);
+          } finally {
+            csvLoadPromise = null;
+          }
+        },
+        error: (error) => {
+          csvLoadPromise = null;
+          reject(error);
+        }
+      });
+    });
+    return csvLoadPromise;
+  }
+
+  function formatTimelineEvent(record) {
+    const { parsedDate } = record;
+    return {
+      id: `csv-${record.index}`,
+      origin: 'csv',
+      title: record.event,
+      summary: '',
+      type: record.type,
+      year: parsedDate.year,
+      yearDisplay: parsedDate.yearDisplay || record.yearString || '',
+      month: parsedDate.month,
+      monthPadded: parsedDate.monthPadded,
+      day: parsedDate.day,
+      monthName: parsedDate.monthName,
+      displayDate: parsedDate.displayDate,
+      dateText: parsedDate.dateText,
+      sortKey: parsedDate.sortKey,
+      link: record.sourceLink,
+      sourceLabel: record.sourceLabel,
+      sourceRaw: record.source,
+      rawDate: record.dateRaw
+    };
+  }
+
+  function deriveTimelineEventFromLocal(entry, index) {
+    const year = entry.year ? parseInt(entry.year, 10) : null;
+    const month = entry.month ? parseInt(entry.month, 10) : null;
+    const day = entry.day ? parseInt(entry.day, 10) : null;
+    const monthName = month ? monthNames[month - 1] || '' : '';
+    const sortKey = createSortKey(year, month, day, entry.createdAt);
+    const sourceInfo = normaliseSource(entry.link || '');
+    const monthPortion = monthName ? `${monthName}${day ? ` ${day}` : ''}` : '';
+    const fallbackDisplay = entry.displayDate || monthPortion;
+    const dateText = fallbackDisplay
+      ? year
+        ? `${fallbackDisplay}${fallbackDisplay.includes(String(year)) ? '' : `, ${year}`}`
+        : fallbackDisplay
+      : (year ? String(year) : '');
+
+    return {
+      id: `local-${index}-${sortKey}`,
+      origin: 'local',
+      title: entry.title || '',
+      summary: entry.summary || '',
+      type: entry.type || 'Community submission',
+      year,
+      yearDisplay: year ? String(year) : (entry.year || ''),
+      month,
+      monthPadded: month ? pad(month) : '',
+      day,
+      monthName,
+      displayDate: fallbackDisplay,
+      dateText,
+      sortKey,
+      link: entry.link || '',
+      sourceLabel: sourceInfo.label || (entry.link ? 'Link' : ''),
+      sourceRaw: entry.link || '',
+      rawDate: fallbackDisplay,
+      imageData: entry.imageData || ''
+    };
+  }
+
+  function mergeTimelineEvents(csvEvents, localEntries) {
+    const combined = [...csvEvents, ...localEntries];
+    combined.sort((a, b) => {
+      const aKey = typeof a.sortKey === 'number' ? a.sortKey : Number.MAX_SAFE_INTEGER;
+      const bKey = typeof b.sortKey === 'number' ? b.sortKey : Number.MAX_SAFE_INTEGER;
+      return bKey - aKey;
+    });
+    return combined;
+  }
+
+  function loadTimelineEvents() {
+    const localEntries = readStorage(STORAGE_KEYS.timeline).map(deriveTimelineEventFromLocal);
+    return getCsvRecords()
+      .then((records) => records.map(formatTimelineEvent))
+      .then((csvEvents) => mergeTimelineEvents(csvEvents, localEntries))
+      .catch((error) => {
+        console.warn('Unable to load CSV timeline data', error);
+        if (localEntries.length) {
+          return mergeTimelineEvents([], localEntries);
+        }
+        throw error;
+      });
+  }
+
+  function formatTrackerItem(record) {
+    const { parsedDate } = record;
+    const status = record.type || 'Uncategorized';
+    return {
+      id: `csv-${record.index}`,
+      origin: 'csv',
+      title: record.event,
+      status,
+      statusDisplay: status,
+      organization: record.sourceLabel,
+      type: record.type,
+      description: record.event,
+      sourceLink: record.sourceLink,
+      sourceLabel: record.sourceLabel,
+      dateDisplay: parsedDate.dateText || record.dateRaw || record.yearString || '',
+      sortKey: parsedDate.sortKey,
+      recordedAt: parsedDate.dateText || '',
+      rawDate: record.dateRaw,
+      yearDisplay: parsedDate.yearDisplay || record.yearString || ''
+    };
+  }
+
+  function formatIsoDate(value) {
+    if (!value) {
+      return '';
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return String(value);
+    }
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  }
+
+  function deriveTrackerItemFromLocal(entry, index) {
+    let year = null;
+    let month = null;
+    let day = null;
+    let displayDate = entry.dateDisplay || '';
+    if (entry.date) {
+      const date = new Date(entry.date);
+      if (!Number.isNaN(date.getTime())) {
+        year = date.getFullYear();
+        month = date.getMonth() + 1;
+        day = date.getDate();
+        displayDate = date.toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        });
+      }
+    }
+    const sortKey = createSortKey(year, month, day, entry.createdAt || entry.date);
+    const linkInfo = normaliseSource(entry.link || '');
+    return {
+      id: `local-${index}-${sortKey}`,
+      origin: 'local',
+      title: entry.title || '',
+      status: entry.status || 'Submitted',
+      statusDisplay: entry.status || 'Submitted',
+      organization: entry.organization || '',
+      type: entry.type || '',
+      description: entry.description || '',
+      sourceLink: linkInfo.link,
+      sourceLabel: entry.linkLabel || linkInfo.label,
+      dateDisplay: displayDate || entry.date || '',
+      sortKey,
+      recordedAt: formatIsoDate(entry.actionDate || ''),
+      rawDate: entry.date || '',
+      yearDisplay: year ? String(year) : (entry.year || '')
+    };
+  }
+
+  function mergeTrackerItems(csvItems, localItems) {
+    const combined = [...csvItems, ...localItems];
+    combined.sort((a, b) => {
+      const aKey = typeof a.sortKey === 'number' ? a.sortKey : Number.MAX_SAFE_INTEGER;
+      const bKey = typeof b.sortKey === 'number' ? b.sortKey : Number.MAX_SAFE_INTEGER;
+      return bKey - aKey;
+    });
+    return combined;
+  }
+
+  function loadTrackerItems() {
+    const localEntries = readStorage(STORAGE_KEYS.tracker).map(deriveTrackerItemFromLocal);
+    return getCsvRecords()
+      .then((records) => records.map(formatTrackerItem))
+      .then((csvItems) => mergeTrackerItems(csvItems, localEntries))
+      .catch((error) => {
+        console.warn('Unable to load CSV tracker data', error);
+        if (localEntries.length) {
+          return mergeTrackerItems([], localEntries);
+        }
+        throw error;
+      });
+  }
+
+  function saveTimelineSubmission(entry) {
+    const current = readStorage(STORAGE_KEYS.timeline);
+    const payload = {
+      ...entry,
+      createdAt: new Date().toISOString()
+    };
+    current.push(payload);
+    writeStorage(STORAGE_KEYS.timeline, current);
+  }
+
+  function saveTrackerSubmission(entry) {
+    const current = readStorage(STORAGE_KEYS.tracker);
+    const payload = {
+      ...entry,
+      createdAt: new Date().toISOString()
+    };
+    current.push(payload);
+    writeStorage(STORAGE_KEYS.tracker, current);
+  }
+
+  window.DataLoader = {
+    loadTimelineEvents,
+    loadTrackerItems,
+    saveTimelineSubmission,
+    saveTrackerSubmission,
+    helpers: {
+      monthNames: monthNames.slice(),
+      pad,
+      normaliseSource,
+      createSortKey,
+      parseDateParts
+    }
+  };
+})(window);

--- a/Harvard/assets/js/timeline.js
+++ b/Harvard/assets/js/timeline.js
@@ -1,0 +1,388 @@
+(function () {
+  const timelineContainer = document.getElementById('timeline');
+  if (!timelineContainer) {
+    return;
+  }
+
+  const yearSelect = document.getElementById('filterYear');
+  const monthSelect = document.getElementById('filterMonth');
+  const messageContainer = document.getElementById('timelineMessage');
+  const typeList = document.getElementById('timelineTypeList');
+  const state = {
+    events: []
+  };
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function setMessage(text, level = 'info') {
+    if (!messageContainer) {
+      return;
+    }
+    if (!text) {
+      messageContainer.classList.add('d-none');
+      messageContainer.textContent = '';
+      return;
+    }
+    messageContainer.classList.remove('d-none');
+    messageContainer.className = `alert alert-${level}`;
+    messageContainer.textContent = text;
+  }
+
+  function clearTimeline() {
+    while (timelineContainer.firstChild) {
+      timelineContainer.removeChild(timelineContainer.firstChild);
+    }
+  }
+
+  function renderEmptyState() {
+    const message = document.createElement('p');
+    message.className = 'text-muted';
+    message.textContent = 'No events match the selected filters yet.';
+    timelineContainer.appendChild(message);
+  }
+
+  function buildMetaList(event) {
+    const list = document.createElement('ul');
+    list.className = 'list-unstyled small mb-0';
+
+    if (event.dateText) {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>Date:</strong> ${escapeHtml(event.dateText)}`;
+      list.appendChild(li);
+    }
+
+    if (event.type) {
+      const li = document.createElement('li');
+      li.innerHTML = `<strong>Category:</strong> ${escapeHtml(event.type)}`;
+      list.appendChild(li);
+    }
+
+    if (event.sourceLabel) {
+      const li = document.createElement('li');
+      const strong = document.createElement('strong');
+      strong.textContent = 'Source:';
+      li.appendChild(strong);
+      li.appendChild(document.createTextNode(' '));
+      if (event.link) {
+        const anchor = document.createElement('a');
+        anchor.href = event.link;
+        anchor.target = '_blank';
+        anchor.rel = 'noopener';
+        anchor.textContent = event.sourceLabel;
+        li.appendChild(anchor);
+      } else {
+        li.appendChild(document.createTextNode(event.sourceLabel));
+      }
+      list.appendChild(li);
+    }
+
+    if (event.origin === 'local') {
+      const li = document.createElement('li');
+      li.innerHTML = '<strong>Note:</strong> Added via submission form';
+      list.appendChild(li);
+    }
+
+    return list;
+  }
+
+  function buildTimelineRow(event) {
+    const row = document.createElement('div');
+    row.className = 'row timeline-row';
+    if (event.yearDisplay) {
+      row.dataset.year = event.yearDisplay;
+    }
+    if (event.monthPadded) {
+      row.dataset.month = event.monthPadded;
+    }
+    if (event.type) {
+      row.dataset.type = event.type;
+    }
+
+    const yearCol = document.createElement('div');
+    yearCol.className = 'col-2 fw-bold';
+    yearCol.textContent = event.yearDisplay || '—';
+
+    const dateCol = document.createElement('div');
+    dateCol.className = 'col-2 text-center';
+    if (event.monthName) {
+      const monthDiv = document.createElement('div');
+      monthDiv.textContent = event.monthName;
+      dateCol.appendChild(monthDiv);
+      if (event.day) {
+        const dayDiv = document.createElement('div');
+        dayDiv.className = 'fw-bold fs-5';
+        dayDiv.textContent = event.day;
+        dateCol.appendChild(dayDiv);
+      } else if (event.displayDate && event.displayDate !== event.monthName) {
+        const textDiv = document.createElement('div');
+        textDiv.textContent = event.displayDate;
+        dateCol.appendChild(textDiv);
+      }
+    } else if (event.displayDate) {
+      const displayDiv = document.createElement('div');
+      displayDiv.textContent = event.displayDate;
+      dateCol.appendChild(displayDiv);
+    }
+
+    const timelineCol = document.createElement('div');
+    timelineCol.className = 'col-1 timeline-col';
+    timelineCol.innerHTML = '<div class="timeline-line"></div><div class="timeline-dot"></div>';
+
+    const eventCol = document.createElement('div');
+    eventCol.className = 'col-7 timeline-event';
+
+    const preview = document.createElement('div');
+    preview.className = 'timeline-preview';
+    const previewTitle = document.createElement('h2');
+    previewTitle.className = 'h5 mb-1';
+    previewTitle.textContent = event.title || 'Untitled event';
+    preview.appendChild(previewTitle);
+    const previewSummary = document.createElement('p');
+    previewSummary.className = 'mb-0';
+    const previewText = event.summary || event.type || event.sourceLabel || '';
+    if (previewText) {
+      previewSummary.textContent = previewText;
+      preview.appendChild(previewSummary);
+    }
+
+    const card = document.createElement('div');
+    card.className = 'card timeline-card';
+    const cardBody = document.createElement('div');
+    cardBody.className = 'card-body';
+    const textArea = document.createElement('div');
+    textArea.className = 'card-text-area';
+
+    const cardTitle = document.createElement('h2');
+    cardTitle.className = 'h5';
+    cardTitle.textContent = event.title || 'Untitled event';
+    textArea.appendChild(cardTitle);
+
+    if (event.summary) {
+      const summaryParagraph = document.createElement('p');
+      summaryParagraph.textContent = event.summary;
+      textArea.appendChild(summaryParagraph);
+    } else if (event.type || event.sourceLabel) {
+      const summaryParagraph = document.createElement('p');
+      const fragments = [];
+      if (event.type) {
+        fragments.push(event.type);
+      }
+      if (event.sourceLabel) {
+        fragments.push(`Source: ${event.sourceLabel}`);
+      }
+      summaryParagraph.textContent = fragments.join(' \u2014 ');
+      textArea.appendChild(summaryParagraph);
+    } else {
+      const placeholder = document.createElement('p');
+      placeholder.className = 'text-muted';
+      placeholder.textContent = 'No additional summary provided.';
+      textArea.appendChild(placeholder);
+    }
+
+    textArea.appendChild(buildMetaList(event));
+    cardBody.appendChild(textArea);
+
+    if (event.imageData) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'image-wrapper';
+      const img = document.createElement('img');
+      img.src = event.imageData;
+      img.alt = 'Submitted event image';
+      wrapper.appendChild(img);
+      cardBody.appendChild(wrapper);
+    }
+
+    card.appendChild(cardBody);
+    eventCol.appendChild(preview);
+    eventCol.appendChild(card);
+
+    eventCol.addEventListener('click', (evt) => {
+      if (evt.target.closest('a')) {
+        return;
+      }
+      const isActive = row.classList.contains('active');
+      document.querySelectorAll('#timeline .timeline-row.active').forEach((openRow) => {
+        if (openRow !== row) {
+          openRow.classList.remove('active');
+        }
+      });
+      if (isActive) {
+        row.classList.remove('active');
+      } else {
+        row.classList.add('active');
+      }
+    });
+
+    row.appendChild(yearCol);
+    row.appendChild(dateCol);
+    row.appendChild(timelineCol);
+    row.appendChild(eventCol);
+
+    return row;
+  }
+
+  function renderTimeline(events) {
+    clearTimeline();
+    if (!events.length) {
+      renderEmptyState();
+      return;
+    }
+    events.forEach((event) => {
+      timelineContainer.appendChild(buildTimelineRow(event));
+    });
+  }
+
+  function populateYearFilter(events) {
+    if (!yearSelect) {
+      return;
+    }
+    const currentValue = yearSelect.value;
+    while (yearSelect.options.length > 1) {
+      yearSelect.remove(1);
+    }
+    const years = Array.from(new Set(events
+      .map((event) => event.yearDisplay)
+      .filter((value) => value)));
+    years.sort((a, b) => {
+      const aNum = parseInt(a, 10);
+      const bNum = parseInt(b, 10);
+      if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+        return bNum - aNum;
+      }
+      return String(b).localeCompare(String(a));
+    });
+    years.forEach((year) => {
+      const option = document.createElement('option');
+      option.value = year;
+      option.textContent = year;
+      yearSelect.appendChild(option);
+    });
+    if (currentValue && years.includes(currentValue)) {
+      yearSelect.value = currentValue;
+    } else {
+      yearSelect.value = '';
+    }
+  }
+
+  function populateMonthFilter(events) {
+    if (!monthSelect) {
+      return;
+    }
+    const currentValue = monthSelect.value;
+    while (monthSelect.options.length > 1) {
+      monthSelect.remove(1);
+    }
+    const monthMap = new Map();
+    events.forEach((event) => {
+      if (event.monthPadded && event.monthName && !monthMap.has(event.monthPadded)) {
+        monthMap.set(event.monthPadded, event.monthName);
+      }
+    });
+    Array.from(monthMap.entries())
+      .sort((a, b) => parseInt(a[0], 10) - parseInt(b[0], 10))
+      .forEach(([value, label]) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label;
+        monthSelect.appendChild(option);
+      });
+    if (currentValue && monthMap.has(currentValue)) {
+      monthSelect.value = currentValue;
+    } else {
+      monthSelect.value = '';
+    }
+  }
+
+  function populateTypeSummary(events) {
+    if (!typeList) {
+      return;
+    }
+    typeList.innerHTML = '';
+    const counts = new Map();
+    events.forEach((event) => {
+      if (!event.type) {
+        return;
+      }
+      const key = event.type.trim();
+      if (!key) {
+        return;
+      }
+      counts.set(key, (counts.get(key) || 0) + 1);
+    });
+    if (!counts.size) {
+      typeList.classList.add('d-none');
+      return;
+    }
+    typeList.classList.remove('d-none');
+    Array.from(counts.entries())
+      .sort((a, b) => {
+        if (b[1] === a[1]) {
+          return a[0].localeCompare(b[0]);
+        }
+        return b[1] - a[1];
+      })
+      .forEach(([type, count]) => {
+        const item = document.createElement('li');
+        item.className = 'list-group-item d-flex flex-column';
+        const label = document.createElement('span');
+        label.textContent = type;
+        const badge = document.createElement('span');
+        badge.className = 'small text-muted';
+        badge.textContent = `${count} item${count === 1 ? '' : 's'}`;
+        item.appendChild(label);
+        item.appendChild(badge);
+        typeList.appendChild(item);
+      });
+  }
+
+  function applyFilters() {
+    const yearFilter = yearSelect ? yearSelect.value : '';
+    const monthFilter = monthSelect ? monthSelect.value : '';
+    const filtered = state.events.filter((event) => {
+      const matchesYear = !yearFilter || String(event.yearDisplay) === yearFilter;
+      const matchesMonth = !monthFilter || event.monthPadded === monthFilter;
+      return matchesYear && matchesMonth;
+    });
+    renderTimeline(filtered);
+  }
+
+  function setupFilters() {
+    if (yearSelect) {
+      yearSelect.addEventListener('change', applyFilters);
+    }
+    if (monthSelect) {
+      monthSelect.addEventListener('change', applyFilters);
+    }
+  }
+
+  function initialise() {
+    setMessage('Loading timeline entries…', 'info');
+    DataLoader.loadTimelineEvents()
+      .then((events) => {
+        state.events = events;
+        populateYearFilter(events);
+        populateMonthFilter(events);
+        populateTypeSummary(events);
+        applyFilters();
+        setMessage('', 'info');
+      })
+      .catch(() => {
+        setMessage('Unable to load timeline entries right now. Saved form submissions will still appear once data is available.', 'danger');
+        renderTimeline([]);
+      });
+    setupFilters();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialise);
+  } else {
+    initialise();
+  }
+})();

--- a/Harvard/assets/js/tracker.js
+++ b/Harvard/assets/js/tracker.js
@@ -1,0 +1,187 @@
+(function () {
+  const tableBody = document.querySelector('#accordionData tbody');
+  if (!tableBody) {
+    return;
+  }
+
+  const messageContainer = document.getElementById('trackerMessage');
+  const offcanvas = document.getElementById('offcanvasNav');
+  const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function setMessage(text, level = 'info') {
+    if (!messageContainer) {
+      return;
+    }
+    if (!text) {
+      messageContainer.classList.add('d-none');
+      messageContainer.textContent = '';
+      return;
+    }
+    messageContainer.classList.remove('d-none');
+    messageContainer.className = `alert alert-${level}`;
+    messageContainer.textContent = text;
+  }
+
+  function getStatusClass(status) {
+    if (!status) {
+      return '';
+    }
+    const value = status.toLowerCase();
+    if (value.includes('resolved') || value.includes('closed') || value.includes('complete')) {
+      return 'status-resolved';
+    }
+    if (value.includes('progress') || value.includes('ongoing') || value.includes('submitted')) {
+      return 'status-progress';
+    }
+    if (value.includes('not') || value.includes('open') || value.includes('pending')) {
+      return 'status-not-taken';
+    }
+    return '';
+  }
+
+  function buildDetailRow(label, content) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'row mb-2';
+    const labelCol = document.createElement('div');
+    labelCol.className = 'col-4 col-md-3 fw-semibold';
+    labelCol.textContent = label;
+    const valueCol = document.createElement('div');
+    valueCol.className = 'col-8 col-md-9';
+    if (content instanceof Node) {
+      valueCol.appendChild(content);
+    } else {
+      valueCol.innerHTML = content;
+    }
+    wrapper.appendChild(labelCol);
+    wrapper.appendChild(valueCol);
+    return wrapper;
+  }
+
+  function buildLink(label, url) {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.target = '_blank';
+    anchor.rel = 'noopener';
+    anchor.textContent = label;
+    return anchor;
+  }
+
+  function renderEmptyState() {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 4;
+    cell.className = 'text-center py-4 text-muted';
+    cell.textContent = 'No tracker items available yet.';
+    row.appendChild(cell);
+    tableBody.appendChild(row);
+  }
+
+  function renderTable(items) {
+    tableBody.innerHTML = '';
+    if (!items.length) {
+      renderEmptyState();
+      return;
+    }
+
+    items.forEach((item, index) => {
+      const collapseId = `trackerCollapse${index}`;
+      const statusClass = getStatusClass(item.statusDisplay);
+
+      const toggleRow = document.createElement('tr');
+      toggleRow.className = `accordion-toggle collapsed ${statusClass}`.trim();
+      toggleRow.setAttribute('role', 'button');
+      toggleRow.setAttribute('data-bs-toggle', 'collapse');
+      toggleRow.setAttribute('data-bs-target', `#${collapseId}`);
+      toggleRow.setAttribute('aria-expanded', 'false');
+      toggleRow.setAttribute('aria-controls', collapseId);
+
+      const dateCell = document.createElement('td');
+      dateCell.textContent = item.dateDisplay || item.yearDisplay || '—';
+      const titleCell = document.createElement('td');
+      titleCell.textContent = item.title || 'Untitled recommendation';
+      const statusCell = document.createElement('td');
+      statusCell.textContent = item.statusDisplay || '';
+      const expandCell = document.createElement('td');
+      expandCell.className = 'expand-button';
+      expandCell.innerHTML = '<span class="toggle-icon"><i class="bi bi-chevron-down"></i></span>';
+
+      toggleRow.appendChild(dateCell);
+      toggleRow.appendChild(titleCell);
+      toggleRow.appendChild(statusCell);
+      toggleRow.appendChild(expandCell);
+
+      const detailRow = document.createElement('tr');
+      const detailCell = document.createElement('td');
+      detailCell.colSpan = 4;
+      const collapse = document.createElement('div');
+      collapse.id = collapseId;
+      collapse.className = 'collapse accordion-body p-3';
+      collapse.setAttribute('data-bs-parent', '#accordionData');
+
+      const container = document.createElement('div');
+      container.className = 'container-fluid';
+
+      container.appendChild(buildDetailRow('Organization', escapeHtml(item.organization || '—')));
+      container.appendChild(buildDetailRow('Category', escapeHtml(item.type || item.statusDisplay || '—')));
+      container.appendChild(buildDetailRow('Details', escapeHtml(item.description || '—')));
+
+      if (item.sourceLink) {
+        container.appendChild(buildDetailRow('Source', buildLink(item.sourceLabel || item.sourceLink, item.sourceLink)));
+      } else if (item.sourceLabel) {
+        container.appendChild(buildDetailRow('Source', escapeHtml(item.sourceLabel)));
+      }
+
+      if (item.recordedAt) {
+        container.appendChild(buildDetailRow('Last updated', escapeHtml(item.recordedAt)));
+      }
+
+      if (item.origin === 'local') {
+        container.appendChild(buildDetailRow('Note', 'Added via submission form. Refresh this page after submitting to see your update.'));
+      }
+
+      collapse.appendChild(container);
+      detailCell.appendChild(collapse);
+      detailRow.appendChild(detailCell);
+
+      tableBody.appendChild(toggleRow);
+      tableBody.appendChild(detailRow);
+    });
+  }
+
+  function initialiseOffcanvas() {
+    if (!offcanvas || !toggler) {
+      return;
+    }
+    offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
+    offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
+  }
+
+  function initialise() {
+    setMessage('Loading tracker items…', 'info');
+    DataLoader.loadTrackerItems()
+      .then((items) => {
+        renderTable(items);
+        setMessage('', 'info');
+      })
+      .catch(() => {
+        renderTable([]);
+        setMessage('Unable to load tracker information right now. Locally saved submissions will appear once data is accessible.', 'danger');
+      });
+    initialiseOffcanvas();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialise);
+  } else {
+    initialise();
+  }
+})();


### PR DESCRIPTION
## Summary
- parse the shared timeline CSV with PapaParse and feed it into reusable data loader utilities
- replace the static timeline and tracker markup with dynamic renders driven by CSV data plus locally stored submissions
- have the timeline and tracker forms persist submissions locally (and optionally post to Apps Script) so future entries appear without redeploying

## Testing
- not run (front-end changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d0a9c1106c8323a7ea78cf16f99880