### PR TITLE
Align Timeline Bootstrap bundle version

### DIFF
--- a/Harvard/Timeline.html
+++ b/Harvard/Timeline.html
@@ -391,6 +391,6 @@
     }
   });
 </script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- align the Timeline page's Bootstrap bundle reference with the existing 5.3.2 stylesheet so both assets load from the same release

## Testing
- Manual: attempted to run a Playwright-based smoke test for offcanvas/filter interactions (blocked by proxy preventing Playwright installation)


------
https://chatgpt.com/codex/tasks/task_e_68d1dd46bf7c8323a1792a6592562900