### PR TITLE
Connect forms to timeline and tracker data store

### DIFF
--- a/Harvard/Timeline-form.html
+++ b/Harvard/Timeline-form.html
@@ -6,54 +6,6 @@
   <title>Add Timeline Event</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
-  <script>
-    const SHEET_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
-
-    async function handleSubmit(e) {
-      e.preventDefault();
-      const form = document.getElementById("timelineForm");
-      const fileInput = document.getElementById("file");
-
-      let fileData = "";
-      let filetype = "";
-      let filename = "";
-
-      if (fileInput.files.length > 0) {
-        const file = fileInput.files[0];
-        filename = file.name;
-        filetype = file.type;
-        const reader = new FileReader();
-        reader.onloadend = async function() {
-          fileData = btoa(reader.result);
-
-          let formData = new URLSearchParams();
-          formData.append("sheet","Timeline");
-          formData.append("eventName", form.eventName.value);
-          formData.append("day", form.day.value);
-          formData.append("month", form.month.value);
-          formData.append("year", form.year.value);
-          formData.append("summary", form.summary.value);
-          formData.append("link", form.link.value);
-          formData.append("file", fileData);
-          formData.append("filename", filename);
-          formData.append("filetype", filetype);
-
-          await fetch(SHEET_URL, { method: "POST", body: formData });
-          alert("Event submitted!");
-          form.reset();
-        };
-        reader.readAsBinaryString(file);
-      } else {
-        // No file, just submit text data
-        let formData = new URLSearchParams(new FormData(form));
-        formData.append("sheet","Timeline");
-
-        await fetch(SHEET_URL, { method: "POST", body: formData });
-        alert("Event submitted (no image)!");
-        form.reset();
-      }
-    }
-  </script>
     <style>
     /* Custom Hamburger / X toggler */
     .navbar-toggler {
@@ -155,7 +107,7 @@
 
 <div class="container my-5">
   <h2>Submit Timeline Event</h2>
-  <form id="timelineForm" onsubmit="handleSubmit(event)">
+  <form id="timelineForm">
     <input class="form-control mb-2" name="eventName" placeholder="Event Name" required>
     <input class="form-control mb-2" type="number" name="day" placeholder="Day">
     <input class="form-control mb-2" type="number" name="month" placeholder="Month (1-12)">
@@ -175,8 +127,62 @@
   <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
 </footer>
 </div>
+<script src="harvard-data-store.js"></script>
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!window.HarvardDataStore) {
+      console.error('HarvardDataStore is not available.');
+      return;
+    }
+
+    initTimelineForm();
+    initOffcanvasToggler();
+  });
+
+  async function initTimelineForm() {
+    await window.HarvardDataStore.ensureTimelineSeeded();
+
+    const form = document.getElementById('timelineForm');
+    const fileInput = document.getElementById('file');
+
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+
+      const payload = {
+        title: form.eventName.value.trim(),
+        eventName: form.eventName.value.trim(),
+        day: form.day.value,
+        month: form.month.value,
+        year: form.year.value,
+        summary: form.summary.value.trim(),
+        link: form.link.value.trim()
+      };
+
+      if (fileInput && fileInput.files.length > 0) {
+        try {
+          payload.imageUrl = await readFileAsDataUrl(fileInput.files[0]);
+        } catch (error) {
+          console.error('Failed to read file', error);
+          alert('Could not read the selected image. Please try again.');
+          return;
+        }
+      }
+
+      window.HarvardDataStore.addTimelineEvent(payload);
+      form.reset();
+      if (fileInput) {
+        fileInput.value = '';
+      }
+      alert('Event submitted! You can review it on the Timeline page.');
+      window.location.href = 'Timeline.html';
+    });
+  }
+
+  function initOffcanvasToggler() {
     const offcanvas = document.getElementById('offcanvasNav');
     const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
 
@@ -184,7 +190,16 @@
       offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
       offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
     }
-  });
+  }
+
+  function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+  }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/Timeline.html
+++ b/Harvard/Timeline.html
@@ -236,13 +236,9 @@
 </div>
 
 <div class="p-2">
-<ul class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4">
-    <li class="list-group-item">Item 1</li>
-    <li class="list-group-item">Item 2</li>
-    <li class="list-group-item">Item 3</li>
-    <li class="list-group-item">Item 4</li>
-    <li class="list-group-item">Item 5</li>
-</ul>
+  <ul id="timelineHighlights" class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4">
+    <!-- Populated dynamically -->
+  </ul>
 </div>
 
 <div class="container mb-4">
@@ -250,72 +246,7 @@
     <!-- Timeline on the left -->
     <div class="col-lg-9 col-md-8">
       <div id="timeline">
-        <!-- Event Row -->
-        <div class="row timeline-row" data-year="2025" data-month="09" data-type="conference">
-          <div class="col-2 fw-bold">2025</div>
-          <div class="col-2 text-center">
-            <div>September</div>
-            <div class="fw-bold fs-5">17</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Tech Conference</h2>
-              <p class="mb-0">A brief description of the event.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Tech Conference</h2>
-                  <p>
-                    A longer paragraph about the event. Details about speakers, 
-                    location, and significance go here. This section will scroll 
-                    if content is longer than the allocated space.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="event image.jpg" alt="Event image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Another Event -->
-        <div class="row timeline-row" data-year="2024" data-month="02" data-type="project">
-          <div class="col-2 fw-bold">2024</div>
-          <div class="col-2 text-center">
-            <div>February</div>
-            <div class="fw-bold fs-5">12</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Website Launch</h2>
-              <p class="mb-0">The new company site goes live.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Website Launch</h2>
-                  <p>
-                    Details about the project, the team involved, and future goals. 
-                    If this text is long, it will also scroll independently.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="https://via.placeholder.com/600x400" alt="Project image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <!-- Populated dynamically -->
       </div>
     </div>
 
@@ -324,14 +255,9 @@
       <div class="d-flex flex-column align-items-end gap-3">
         <select class="form-select w-auto" id="filterYear">
           <option value="">All Years</option>
-          <option value="2024">2024</option>
-          <option value="2025">2025</option>
         </select>
         <select class="form-select w-auto" id="filterMonth">
           <option value="">All Months</option>
-          <option value="01">January</option>
-          <option value="02">February</option>
-          <option value="09">September</option>
         </select>
       </div>
     </div>
@@ -346,9 +272,311 @@
   <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
 </footer>
 
+<script src="harvard-data-store.js"></script>
 <script>
-  // Filtering logic
   const filters = { year: '', month: '', type: '' };
+  const monthNames = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+  ];
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    if (!window.HarvardDataStore) {
+      console.error('HarvardDataStore is not available.');
+      return;
+    }
+
+    await window.HarvardDataStore.ensureTimelineSeeded();
+    const events = window.HarvardDataStore.getTimelineEvents();
+    populateFilters(events);
+    renderTimeline(events);
+    setupFilterHandlers();
+    initOffcanvasToggler();
+  });
+
+  function renderTimeline(events) {
+    const timelineContainer = document.getElementById('timeline');
+    if (!timelineContainer) {
+      return;
+    }
+
+    timelineContainer.innerHTML = '';
+
+    if (!events.length) {
+      const emptyMessage = document.createElement('p');
+      emptyMessage.className = 'text-muted';
+      emptyMessage.textContent = 'No events have been added yet.';
+      timelineContainer.appendChild(emptyMessage);
+      updateHighlights([]);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    events.forEach((event, index) => {
+      fragment.appendChild(createTimelineRow(event, index));
+    });
+
+    timelineContainer.appendChild(fragment);
+    updateHighlights(events);
+    attachTimelineEventListeners();
+    applyFilters();
+  }
+
+  function createTimelineRow(event, index) {
+    const row = document.createElement('div');
+    row.className = 'row timeline-row';
+    row.dataset.year = event.year || '';
+    row.dataset.month = event.month || '';
+    row.dataset.type = event.type || '';
+
+    const yearCol = document.createElement('div');
+    yearCol.className = 'col-2 fw-bold';
+    yearCol.textContent = event.year || '';
+    row.appendChild(yearCol);
+
+    const dateCol = document.createElement('div');
+    dateCol.className = 'col-2 text-center';
+    const monthLabel = document.createElement('div');
+    monthLabel.textContent = formatMonthName(event.month);
+    const dayLabel = document.createElement('div');
+    dayLabel.className = 'fw-bold fs-5';
+    dayLabel.textContent = formatDay(event.day);
+    dateCol.append(monthLabel, dayLabel);
+    row.appendChild(dateCol);
+
+    const timelineCol = document.createElement('div');
+    timelineCol.className = 'col-1 timeline-col';
+    const line = document.createElement('div');
+    line.className = 'timeline-line';
+    const dot = document.createElement('div');
+    dot.className = 'timeline-dot';
+    timelineCol.append(line, dot);
+    row.appendChild(timelineCol);
+
+    const eventCol = document.createElement('div');
+    eventCol.className = 'col-7 timeline-event';
+
+    const preview = document.createElement('div');
+    preview.className = 'timeline-preview';
+    const previewTitle = document.createElement('h2');
+    previewTitle.className = 'h5 mb-1';
+    previewTitle.textContent = event.title || event.eventName || 'Untitled Event';
+    const previewSummary = document.createElement('p');
+    previewSummary.className = 'mb-0';
+    previewSummary.textContent = createPreviewText(event.summary);
+    preview.append(previewTitle, previewSummary);
+
+    const card = document.createElement('div');
+    card.className = 'card timeline-card';
+    const cardBody = document.createElement('div');
+    cardBody.className = 'card-body';
+
+    const textArea = document.createElement('div');
+    textArea.className = 'card-text-area';
+    const cardTitle = document.createElement('h2');
+    cardTitle.className = 'h5';
+    cardTitle.textContent = event.title || event.eventName || 'Untitled Event';
+    textArea.appendChild(cardTitle);
+
+    if (event.summary) {
+      const summaryParagraph = document.createElement('p');
+      summaryParagraph.textContent = event.summary;
+      textArea.appendChild(summaryParagraph);
+    }
+
+    const safeLink = sanitizeUrl(event.link);
+    if (safeLink) {
+      const linkParagraph = document.createElement('p');
+      const link = document.createElement('a');
+      link.href = safeLink;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = 'Read more';
+      linkParagraph.appendChild(link);
+      textArea.appendChild(linkParagraph);
+    }
+
+    cardBody.appendChild(textArea);
+
+    if (event.imageUrl) {
+      const imageWrapper = document.createElement('div');
+      imageWrapper.className = 'image-wrapper';
+      const image = document.createElement('img');
+      image.src = event.imageUrl;
+      image.alt = event.title || event.eventName || 'Timeline event image';
+      imageWrapper.appendChild(image);
+      cardBody.appendChild(imageWrapper);
+    }
+
+    if (event.createdAt) {
+      const submitted = document.createElement('small');
+      submitted.className = 'text-muted d-block mt-2';
+      submitted.textContent = `Submitted: ${formatDateTime(event.createdAt)}`;
+      cardBody.appendChild(submitted);
+    }
+
+    card.appendChild(cardBody);
+    eventCol.append(preview, card);
+    row.appendChild(eventCol);
+
+    return row;
+  }
+
+  function createPreviewText(summary = '') {
+    const text = summary.trim();
+    if (!text) {
+      return 'Tap to view details.';
+    }
+    return text.length > 120 ? `${text.slice(0, 117)}…` : text;
+  }
+
+  function formatMonthName(month) {
+    const monthIndex = Number.parseInt(month, 10);
+    if (!Number.isFinite(monthIndex) || monthIndex < 1 || monthIndex > 12) {
+      return '';
+    }
+    return monthNames[monthIndex - 1];
+  }
+
+  function formatDay(day) {
+    const numericDay = Number.parseInt(day, 10);
+    if (!Number.isFinite(numericDay) || numericDay < 1) {
+      return '';
+    }
+    return String(numericDay).padStart(2, '0');
+  }
+
+  function sanitizeUrl(url) {
+    const trimmed = (url || '').trim();
+    if (!trimmed) {
+      return '';
+    }
+
+    try {
+      const parsed = new URL(trimmed, window.location.origin);
+      if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+        return parsed.href;
+      }
+    } catch (error) {
+      return '';
+    }
+
+    return '';
+  }
+
+  function formatDateTime(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    return date.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  }
+
+  function attachTimelineEventListeners() {
+    document.querySelectorAll('.timeline-event').forEach(eventCol => {
+      eventCol.addEventListener('click', () => {
+        const row = eventCol.closest('.timeline-row');
+        document.querySelectorAll('.timeline-row.active').forEach(openRow => {
+          if (openRow !== row) {
+            openRow.classList.remove('active');
+          }
+        });
+        row.classList.toggle('active');
+      });
+    });
+  }
+
+  function updateHighlights(events) {
+    const list = document.getElementById('timelineHighlights');
+    if (!list) {
+      return;
+    }
+
+    list.innerHTML = '';
+
+    if (!events.length) {
+      const emptyItem = document.createElement('li');
+      emptyItem.className = 'list-group-item text-muted';
+      emptyItem.textContent = 'No events to highlight yet.';
+      list.appendChild(emptyItem);
+      return;
+    }
+
+    events.slice(0, 5).forEach(event => {
+      const item = document.createElement('li');
+      item.className = 'list-group-item';
+      item.textContent = event.title || event.eventName || 'Untitled Event';
+      list.appendChild(item);
+    });
+  }
+
+  function populateFilters(events) {
+    const yearSelect = document.getElementById('filterYear');
+    const monthSelect = document.getElementById('filterMonth');
+
+    if (yearSelect) {
+      const currentValue = yearSelect.value || filters.year;
+      yearSelect.innerHTML = '<option value="">All Years</option>';
+      const years = Array.from(new Set(events.map(event => event.year).filter(Boolean)))
+        .sort((a, b) => Number.parseInt(b, 10) - Number.parseInt(a, 10));
+
+      years.forEach(year => {
+        const option = document.createElement('option');
+        option.value = year;
+        option.textContent = year;
+        yearSelect.appendChild(option);
+      });
+
+      if (currentValue && years.includes(currentValue)) {
+        yearSelect.value = currentValue;
+        filters.year = currentValue;
+      }
+    }
+
+    if (monthSelect) {
+      const currentValue = monthSelect.value || filters.month;
+      monthSelect.innerHTML = '<option value="">All Months</option>';
+      const months = Array.from(new Set(events.map(event => event.month).filter(Boolean)))
+        .sort((a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10));
+
+      months.forEach(month => {
+        const option = document.createElement('option');
+        option.value = month;
+        option.textContent = formatMonthName(month);
+        monthSelect.appendChild(option);
+      });
+
+      if (currentValue && months.includes(currentValue)) {
+        monthSelect.value = currentValue;
+        filters.month = currentValue;
+      }
+    }
+  }
+
+  function setupFilterHandlers() {
+    const yearSelect = document.getElementById('filterYear');
+    const monthSelect = document.getElementById('filterMonth');
+
+    if (yearSelect) {
+      yearSelect.addEventListener('change', event => {
+        filters.year = event.target.value;
+        applyFilters();
+      });
+    }
+
+    if (monthSelect) {
+      monthSelect.addEventListener('change', event => {
+        filters.month = event.target.value;
+        applyFilters();
+      });
+    }
+  }
 
   function applyFilters() {
     document.querySelectorAll('#timeline .timeline-row').forEach(row => {
@@ -360,28 +588,7 @@
     });
   }
 
-  document.getElementById('filterYear').addEventListener('change', e => {
-    filters.year = e.target.value;
-    applyFilters();
-  });
-  document.getElementById('filterMonth').addEventListener('change', e => {
-    filters.month = e.target.value;
-    applyFilters();
-  });
-
-  // Toggle expand/collapse on click
-  document.querySelectorAll('.timeline-event').forEach(eventCol => {
-    eventCol.addEventListener('click', e => {
-      const row = eventCol.closest('.timeline-row');
-      document.querySelectorAll('.timeline-row.active').forEach(openRow => {
-        if (openRow !== row) openRow.classList.remove('active');
-      });
-      row.classList.toggle('active');
-    });
-  });
-</script>
-<script>
-  document.addEventListener("DOMContentLoaded", () => {
+  function initOffcanvasToggler() {
     const offcanvas = document.getElementById('offcanvasNav');
     const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
 
@@ -389,7 +596,7 @@
       offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
       offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
     }
-  });
+  }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/Tracker-form.html
+++ b/Harvard/Tracker-form.html
@@ -6,19 +6,6 @@
   <title>Add Recommendation</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
-  <script>
-    const SHEET_URL = "YOUR_APPS_SCRIPT_WEBAPP_URL";
-
-    async function handleSubmit(e) {
-      e.preventDefault();
-      let formData = new FormData(document.getElementById("recForm"));
-      formData.append("sheet","Recommendations");
-
-      await fetch(SHEET_URL, { method: "POST", body: formData });
-      alert("Recommendation submitted!");
-      document.getElementById("recForm").reset();
-    }
-  </script>
     <style>
     /* Custom Hamburger / X toggler */
     .navbar-toggler {
@@ -120,7 +107,7 @@
 
 <div class="container my-5">
   <h2>Submit Recommendation</h2>
-  <form id="recForm" onsubmit="handleSubmit(event)">
+  <form id="recForm">
     <input class="form-control mb-2" name="title" placeholder="Recommendation Title" required>
     <input class="form-control mb-2" type="date" name="date" required>
     <input class="form-control mb-2" name="organization" placeholder="Organization">
@@ -143,8 +130,48 @@
   <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
 </footer>
 
+<script src="harvard-data-store.js"></script>
 <script>
-  document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!window.HarvardDataStore) {
+      console.error('HarvardDataStore is not available.');
+      return;
+    }
+
+    initRecommendationForm();
+    initOffcanvasToggler();
+  });
+
+  async function initRecommendationForm() {
+    await window.HarvardDataStore.ensureRecommendationsSeeded();
+
+    const form = document.getElementById('recForm');
+
+    if (!form) {
+      return;
+    }
+
+    form.addEventListener('submit', event => {
+      event.preventDefault();
+
+      const payload = {
+        title: form.title.value.trim(),
+        date: form.date.value,
+        organization: form.organization.value.trim(),
+        type: form.type.value.trim(),
+        status: form.status.value.trim(),
+        actionDate: form.actionDate.value,
+        description: form.description.value.trim()
+      };
+
+      window.HarvardDataStore.addRecommendation(payload);
+      form.reset();
+      alert('Recommendation submitted! You can review it on the Tracker page.');
+      window.location.href = 'Tracker.html';
+    });
+  }
+
+  function initOffcanvasToggler() {
     const offcanvas = document.getElementById('offcanvasNav');
     const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
 
@@ -152,7 +179,7 @@
       offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
       offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
     }
-  });
+  }
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/Tracker.html
+++ b/Harvard/Tracker.html
@@ -152,56 +152,167 @@
     <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
   </footer>
 
+  <script src="harvard-data-store.js"></script>
   <script>
-    async function loadData() {
-      // Fake test data (replace with fetch)
-      const data = [
-        { date: "April 1, 2023", title: "Recommendation 1", status: "Resolved", organization: "Org A", type: "Type A", description: "Fixed issue", timestamp: "2023-04-01" },
-        { date: "April 2, 2023", title: "Recommendation 2", status: "In Progress", organization: "Org B", type: "Type B", description: "Still working", timestamp: "2023-04-02" },
-        { date: "April 3, 2023", title: "Recommendation 3", status: "Not Taken", organization: "Org C", type: "Type C", description: "Not acted upon", timestamp: "2023-04-03" }
-      ];
+    document.addEventListener('DOMContentLoaded', async () => {
+      if (!window.HarvardDataStore) {
+        console.error('HarvardDataStore is not available.');
+        return;
+      }
 
-      const container = document.querySelector("#accordionData tbody");
-      container.innerHTML = "";
+      await window.HarvardDataStore.ensureRecommendationsSeeded();
+      const recommendations = window.HarvardDataStore.getRecommendations();
+      renderRecommendations(recommendations);
+      initOffcanvasToggler();
+    });
 
-      data.forEach((row, i) => {
-        let statusClass = "";
-        if (row.status === "Resolved") statusClass = "status-resolved";
-        else if (row.status === "In Progress") statusClass = "status-progress";
-        else if (row.status === "Not Taken") statusClass = "status-not-taken";
+    function renderRecommendations(recommendations) {
+      const container = document.querySelector('#accordionData tbody');
+      if (!container) {
+        return;
+      }
 
-        container.innerHTML += `
-          <tr class="accordion-toggle collapsed ${statusClass}"
-              role="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#collapse${i}"
-              aria-expanded="false"
-              aria-controls="collapse${i}">
-            <td>${row.date}</td>
-            <td>${row.title}</td>
-            <td>${row.status}</td>
-            <td class="expand-button">
-              <span class="toggle-icon"><i class="bi bi-chevron-down"></i></span>
-            </td>
-          </tr>
-          <tr>
-            <td colspan="4">
-              <div id="collapse${i}" class="collapse accordion-body p-3" data-bs-parent="#accordionData">
-                <div class="row"><div class="col-2">Organization</div><div class="col-6">${row.organization}</div></div>
-                <div class="row"><div class="col-2">Type</div><div class="col-6">${row.type}</div></div>
-                <div class="row"><div class="col-2">Description</div><div class="col-6">${row.description}</div></div>
-                <small><em>Submitted: ${row.timestamp}</em></small>
-              </div>
-            </td>
-          </tr>`;
+      container.innerHTML = '';
+
+      if (!recommendations.length) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 4;
+        cell.className = 'text-center text-muted py-4';
+        cell.textContent = 'No recommendations submitted yet.';
+        row.appendChild(cell);
+        container.appendChild(row);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      recommendations.forEach((recommendation, index) => {
+        const rows = createRecommendationRows(recommendation, index);
+        fragment.appendChild(rows.header);
+        fragment.appendChild(rows.details);
+      });
+
+      container.appendChild(fragment);
+    }
+
+    function createRecommendationRows(recommendation, index) {
+      const collapseId = `collapse${index}`;
+      const headerRow = document.createElement('tr');
+      const statusClass = getStatusClass(recommendation.status);
+      headerRow.className = ['accordion-toggle', 'collapsed', statusClass].filter(Boolean).join(' ');
+      headerRow.setAttribute('role', 'button');
+      headerRow.setAttribute('data-bs-toggle', 'collapse');
+      headerRow.setAttribute('data-bs-target', `#${collapseId}`);
+      headerRow.setAttribute('aria-expanded', 'false');
+      headerRow.setAttribute('aria-controls', collapseId);
+
+      const dateCell = document.createElement('td');
+      dateCell.textContent = formatDateForDisplay(recommendation.date);
+      headerRow.appendChild(dateCell);
+
+      const titleCell = document.createElement('td');
+      titleCell.textContent = recommendation.title || 'Untitled Recommendation';
+      headerRow.appendChild(titleCell);
+
+      const statusCell = document.createElement('td');
+      statusCell.textContent = recommendation.status || '—';
+      headerRow.appendChild(statusCell);
+
+      const expandCell = document.createElement('td');
+      expandCell.className = 'expand-button';
+      const iconWrapper = document.createElement('span');
+      iconWrapper.className = 'toggle-icon';
+      const icon = document.createElement('i');
+      icon.className = 'bi bi-chevron-down';
+      iconWrapper.appendChild(icon);
+      expandCell.appendChild(iconWrapper);
+      headerRow.appendChild(expandCell);
+
+      const detailsRow = document.createElement('tr');
+      const detailCell = document.createElement('td');
+      detailCell.colSpan = 4;
+      const collapse = document.createElement('div');
+      collapse.id = collapseId;
+      collapse.className = 'collapse accordion-body p-3';
+      collapse.setAttribute('data-bs-parent', '#accordionData');
+
+      collapse.appendChild(createDetailRow('Organization', recommendation.organization || '—'));
+      collapse.appendChild(createDetailRow('Type', recommendation.type || '—'));
+      collapse.appendChild(createDetailRow('Description', recommendation.description || '—'));
+
+      if (recommendation.actionDate) {
+        collapse.appendChild(createDetailRow('Action Date', formatDateForDisplay(recommendation.actionDate)));
+      }
+
+      if (recommendation.createdAt) {
+        const submitted = document.createElement('small');
+        submitted.className = 'd-block mt-3 text-muted';
+        submitted.textContent = `Submitted: ${formatDateTime(recommendation.createdAt)}`;
+        collapse.appendChild(submitted);
+      }
+
+      detailCell.appendChild(collapse);
+      detailsRow.appendChild(detailCell);
+
+      return { header: headerRow, details: detailsRow };
+    }
+
+    function createDetailRow(label, value) {
+      const row = document.createElement('div');
+      row.className = 'row mb-2';
+      const labelCol = document.createElement('div');
+      labelCol.className = 'col-3 col-md-2 fw-semibold';
+      labelCol.textContent = label;
+      const valueCol = document.createElement('div');
+      valueCol.className = 'col';
+      valueCol.textContent = value;
+      row.append(labelCol, valueCol);
+      return row;
+    }
+
+    function formatDateForDisplay(value) {
+      if (!value) {
+        return '';
+      }
+
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return value;
+      }
+
+      return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+
+    function formatDateTime(value) {
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+
+      return date.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
       });
     }
 
-    document.addEventListener("DOMContentLoaded", () => {
-      // Load table
-      loadData();
+    function getStatusClass(status) {
+      const normalized = (status || '').toLowerCase();
+      if (normalized === 'closed' || normalized === 'resolved') {
+        return 'status-resolved';
+      }
+      if (normalized === 'in progress') {
+        return 'status-progress';
+      }
+      if (normalized === 'open' || normalized === 'not taken') {
+        return 'status-not-taken';
+      }
+      return '';
+    }
 
-      // Hook the offcanvas events to flip the toggler icon
+    function initOffcanvasToggler() {
       const offcanvas = document.getElementById('offcanvasNav');
       const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
 
@@ -209,7 +320,7 @@
         offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
         offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
       }
-    });
+    }
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/harvard-data-store.js
+++ b/Harvard/harvard-data-store.js
@@ -1,0 +1,328 @@
+(function (window) {
+  'use strict';
+
+  const STORAGE_KEY = 'harvardDataStore';
+  let idCounter = 0;
+
+  const DEFAULT_TIMELINE_DATA = [
+    {
+      id: 'timeline-1',
+      title: 'Tech Conference',
+      eventName: 'Tech Conference',
+      day: '17',
+      month: '09',
+      year: '2025',
+      summary: 'A longer paragraph about the event. Details about speakers, location, and significance go here. This section will scroll if content is longer than the allocated space.',
+      link: 'https://example.com/tech-conference',
+      imageUrl: 'event image.jpg',
+      createdAt: '2025-09-01T12:00:00.000Z'
+    },
+    {
+      id: 'timeline-2',
+      title: 'Website Launch',
+      eventName: 'Website Launch',
+      day: '12',
+      month: '02',
+      year: '2024',
+      summary: 'Details about the project, the team involved, and future goals. If this text is long, it will also scroll independently.',
+      link: 'https://example.com/website-launch',
+      imageUrl: 'https://via.placeholder.com/600x400',
+      createdAt: '2024-02-15T09:30:00.000Z'
+    },
+    {
+      id: 'timeline-3',
+      title: 'Community Forum',
+      eventName: 'Community Forum',
+      day: '05',
+      month: '11',
+      year: '2023',
+      summary: 'Students and faculty gathered to discuss initiatives that support Jewish life on campus.',
+      link: 'https://example.com/community-forum',
+      imageUrl: '',
+      createdAt: '2023-11-06T14:15:00.000Z'
+    }
+  ];
+
+  const DEFAULT_RECOMMENDATION_DATA = [
+    {
+      id: 'recommendation-1',
+      title: 'Expand Cultural Programming',
+      date: '2024-03-01',
+      organization: 'Student Affairs Office',
+      type: 'Programming',
+      status: 'In Progress',
+      actionDate: '2024-03-15',
+      description: 'Collaborate with student groups to offer additional educational events throughout the semester.',
+      createdAt: '2024-03-02T10:00:00.000Z'
+    },
+    {
+      id: 'recommendation-2',
+      title: 'Update Safety Protocols',
+      date: '2024-01-20',
+      organization: 'Campus Security',
+      type: 'Policy',
+      status: 'Open',
+      actionDate: '',
+      description: 'Review and update security procedures to address recent concerns reported by students.',
+      createdAt: '2024-01-21T08:00:00.000Z'
+    },
+    {
+      id: 'recommendation-3',
+      title: 'Publish Annual Report',
+      date: '2023-12-10',
+      organization: 'Office of Communications',
+      type: 'Reporting',
+      status: 'Closed',
+      actionDate: '2024-01-05',
+      description: 'Release a public summary of actions taken to support Jewish campus life over the past year.',
+      createdAt: '2024-01-06T16:45:00.000Z'
+    }
+  ];
+
+  const storageAvailable = checkStorageAvailability();
+  let state = loadInitialState();
+
+  function checkStorageAvailability() {
+    try {
+      const testKey = '__harvard_data_store_test__';
+      window.localStorage.setItem(testKey, '1');
+      window.localStorage.removeItem(testKey);
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function createId(prefix) {
+    idCounter += 1;
+    return `${prefix}-${Date.now()}-${idCounter}`;
+  }
+
+  function toIsoString(value, fallback) {
+    if (!value) {
+      return fallback ? new Date(fallback).toISOString() : new Date().toISOString();
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return fallback ? new Date(fallback).toISOString() : new Date().toISOString();
+    }
+
+    return date.toISOString();
+  }
+
+  function padNumber(value) {
+    const number = Number.parseInt(value, 10);
+    if (!Number.isFinite(number) || number <= 0) {
+      return '';
+    }
+    return String(number).padStart(2, '0');
+  }
+
+  function normalizeNumeric(value) {
+    const number = Number.parseInt(value, 10);
+    if (!Number.isFinite(number) || number <= 0) {
+      return '';
+    }
+    return String(number);
+  }
+
+  function normalizeTimelineEvent(event, { preserveId = false } = {}) {
+    const now = new Date().toISOString();
+    const normalized = {
+      id: preserveId && event.id ? String(event.id) : createId('timeline'),
+      title: (event.title || event.eventName || 'Untitled Event').trim(),
+      eventName: (event.eventName || event.title || 'Untitled Event').trim(),
+      summary: (event.summary || '').trim(),
+      link: (event.link || '').trim(),
+      year: normalizeNumeric(event.year),
+      month: padNumber(event.month),
+      day: padNumber(event.day),
+      imageUrl: (event.imageUrl || '').trim(),
+      createdAt: toIsoString(event.createdAt, now)
+    };
+
+    return normalized;
+  }
+
+  function normalizeRecommendation(rec, { preserveId = false } = {}) {
+    const now = new Date().toISOString();
+    const normalized = {
+      id: preserveId && rec.id ? String(rec.id) : createId('recommendation'),
+      title: (rec.title || 'Untitled Recommendation').trim(),
+      date: normalizeDate(rec.date),
+      organization: (rec.organization || '').trim(),
+      type: (rec.type || '').trim(),
+      status: (rec.status || '').trim(),
+      actionDate: normalizeDate(rec.actionDate),
+      description: (rec.description || '').trim(),
+      createdAt: toIsoString(rec.createdAt, now)
+    };
+
+    return normalized;
+  }
+
+  function normalizeDate(value) {
+    if (!value) {
+      return '';
+    }
+
+    const parsed = Date.parse(value);
+    if (Number.isNaN(parsed)) {
+      return '';
+    }
+
+    return new Date(parsed).toISOString().split('T')[0];
+  }
+
+  function createDefaultState() {
+    return {
+      timelineEvents: DEFAULT_TIMELINE_DATA.map(item => normalizeTimelineEvent(item, { preserveId: true })),
+      recommendations: DEFAULT_RECOMMENDATION_DATA.map(item => normalizeRecommendation(item, { preserveId: true }))
+    };
+  }
+
+  function loadInitialState() {
+    if (!storageAvailable) {
+      return createDefaultState();
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return createDefaultState();
+      }
+
+      const parsed = JSON.parse(raw);
+      const state = createDefaultState();
+
+      if (parsed && typeof parsed === 'object') {
+        if (Array.isArray(parsed.timelineEvents) && parsed.timelineEvents.length > 0) {
+          state.timelineEvents = parsed.timelineEvents.map(item => normalizeTimelineEvent(item, { preserveId: true }));
+        }
+
+        if (Array.isArray(parsed.recommendations) && parsed.recommendations.length > 0) {
+          state.recommendations = parsed.recommendations.map(item => normalizeRecommendation(item, { preserveId: true }));
+        }
+      }
+
+      return state;
+    } catch (error) {
+      console.warn('HarvardDataStore: failed to read from localStorage', error);
+      return createDefaultState();
+    }
+  }
+
+  function persistState() {
+    if (!storageAvailable) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn('HarvardDataStore: failed to persist state', error);
+    }
+  }
+
+  function deepClone(value) {
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function ensureTimelineSeeded() {
+    if (!Array.isArray(state.timelineEvents) || state.timelineEvents.length === 0) {
+      state.timelineEvents = createDefaultState().timelineEvents;
+      persistState();
+    }
+
+    return Promise.resolve(deepClone(state.timelineEvents));
+  }
+
+  function ensureRecommendationsSeeded() {
+    if (!Array.isArray(state.recommendations) || state.recommendations.length === 0) {
+      state.recommendations = createDefaultState().recommendations;
+      persistState();
+    }
+
+    return Promise.resolve(deepClone(state.recommendations));
+  }
+
+  function ensureAllSeeded() {
+    return Promise.all([ensureTimelineSeeded(), ensureRecommendationsSeeded()]);
+  }
+
+  function getTimelineEvents() {
+    if (!Array.isArray(state.timelineEvents)) {
+      return [];
+    }
+
+    return deepClone(state.timelineEvents).sort((a, b) => {
+      const dateA = buildEventTimestamp(a);
+      const dateB = buildEventTimestamp(b);
+      if (dateA > dateB) return -1;
+      if (dateA < dateB) return 1;
+      return 0;
+    });
+  }
+
+  function buildEventTimestamp(event) {
+    const year = Number.parseInt(event.year, 10) || 0;
+    const month = Number.parseInt(event.month, 10) || 1;
+    const day = Number.parseInt(event.day, 10) || 1;
+    const base = Date.UTC(year, month - 1, day);
+    const created = Date.parse(event.createdAt);
+    return Number.isNaN(created) ? base : created;
+  }
+
+  function addTimelineEvent(event) {
+    const normalized = normalizeTimelineEvent(event);
+    state.timelineEvents = [normalized, ...state.timelineEvents];
+    persistState();
+    return normalized;
+  }
+
+  function getRecommendations() {
+    if (!Array.isArray(state.recommendations)) {
+      return [];
+    }
+
+    return deepClone(state.recommendations).sort((a, b) => {
+      const dateA = buildRecommendationTimestamp(a);
+      const dateB = buildRecommendationTimestamp(b);
+      if (dateA > dateB) return -1;
+      if (dateA < dateB) return 1;
+      return 0;
+    });
+  }
+
+  function buildRecommendationTimestamp(rec) {
+    const primary = Date.parse(rec.date);
+    if (!Number.isNaN(primary)) {
+      return primary;
+    }
+
+    const created = Date.parse(rec.createdAt);
+    if (!Number.isNaN(created)) {
+      return created;
+    }
+
+    return 0;
+  }
+
+  function addRecommendation(rec) {
+    const normalized = normalizeRecommendation(rec);
+    state.recommendations = [normalized, ...state.recommendations];
+    persistState();
+    return normalized;
+  }
+
+  window.HarvardDataStore = {
+    ensureTimelineSeeded,
+    ensureRecommendationsSeeded,
+    ensureAllSeeded,
+    getTimelineEvents,
+    addTimelineEvent,
+    getRecommendations,
+    addRecommendation
+  };
+})(window);


### PR DESCRIPTION
## Summary
- add a reusable HarvardDataStore module that seeds local data, persists entries, and exposes helpers for timeline events and recommendations
- update the timeline and tracker forms to push submissions into the shared data store before redirecting to their respective listing pages
- render the timeline and tracker views dynamically from the stored data, including refreshed filters/highlights and collapse details, while preserving the offcanvas toggler behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e346c6bc83238b09e80c9542a233