### PR TITLE
Connect timeline and tracker pages to CSV

### DIFF
--- a/Harvard/Timeline.html
+++ b/Harvard/Timeline.html
@@ -236,87 +236,18 @@
 </div>
 
 <div class="p-2">
-<ul class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4">
-    <li class="list-group-item">Item 1</li>
-    <li class="list-group-item">Item 2</li>
-    <li class="list-group-item">Item 3</li>
-    <li class="list-group-item">Item 4</li>
-    <li class="list-group-item">Item 5</li>
-</ul>
+  <ul id="typeFilters" class="list-group list-group-horizontal position-relative overflow-auto w-75 p-4 gap-2"></ul>
 </div>
 
 <div class="container mb-4">
   <div class="row">
     <!-- Timeline on the left -->
     <div class="col-lg-9 col-md-8">
-      <div id="timeline">
-        <!-- Event Row -->
-        <div class="row timeline-row" data-year="2025" data-month="09" data-type="conference">
-          <div class="col-2 fw-bold">2025</div>
-          <div class="col-2 text-center">
-            <div>September</div>
-            <div class="fw-bold fs-5">17</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Tech Conference</h2>
-              <p class="mb-0">A brief description of the event.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Tech Conference</h2>
-                  <p>
-                    A longer paragraph about the event. Details about speakers, 
-                    location, and significance go here. This section will scroll 
-                    if content is longer than the allocated space.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="event image.jpg" alt="Event image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Another Event -->
-        <div class="row timeline-row" data-year="2024" data-month="02" data-type="project">
-          <div class="col-2 fw-bold">2024</div>
-          <div class="col-2 text-center">
-            <div>February</div>
-            <div class="fw-bold fs-5">12</div>
-          </div>
-          <div class="col-1 timeline-col">
-            <div class="timeline-line"></div>
-            <div class="timeline-dot"></div>
-          </div>
-          <div class="col-7 timeline-event">
-            <div class="timeline-preview">
-              <h2 class="h5 mb-1">Website Launch</h2>
-              <p class="mb-0">The new company site goes live.</p>
-            </div>
-            <div class="card timeline-card">
-              <div class="card-body">
-                <div class="card-text-area">
-                  <h2 class="h5">Website Launch</h2>
-                  <p>
-                    Details about the project, the team involved, and future goals. 
-                    If this text is long, it will also scroll independently.
-                  </p>
-                </div>
-                <div class="image-wrapper">
-                  <img src="https://via.placeholder.com/600x400" alt="Project image">
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+      <div id="timeline"></div>
+      <div id="timelineEmpty" class="text-muted text-center py-4 d-none">
+        No events match the selected filters.
       </div>
+      <div id="timelineError" class="alert alert-danger d-none" role="alert"></div>
     </div>
 
     <!-- Filters on the right -->
@@ -324,14 +255,9 @@
       <div class="d-flex flex-column align-items-end gap-3">
         <select class="form-select w-auto" id="filterYear">
           <option value="">All Years</option>
-          <option value="2024">2024</option>
-          <option value="2025">2025</option>
         </select>
         <select class="form-select w-auto" id="filterMonth">
           <option value="">All Months</option>
-          <option value="01">January</option>
-          <option value="02">February</option>
-          <option value="09">September</option>
         </select>
       </div>
     </div>
@@ -346,50 +272,326 @@
   <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
 </footer>
 
+<script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+<script src="js/data-utils.js"></script>
 <script>
-  // Filtering logic
-  const filters = { year: '', month: '', type: '' };
+  (function () {
+    const filters = { year: '', month: '', type: '' };
+    let events = [];
 
-  function applyFilters() {
-    document.querySelectorAll('#timeline .timeline-row').forEach(row => {
-      const match =
-        (!filters.year || row.dataset.year === filters.year) &&
-        (!filters.month || row.dataset.month === filters.month) &&
-        (!filters.type || row.dataset.type === filters.type);
-      row.style.display = match ? '' : 'none';
+    const timelineEl = document.getElementById('timeline');
+    const emptyStateEl = document.getElementById('timelineEmpty');
+    const errorEl = document.getElementById('timelineError');
+    const typeFilterList = document.getElementById('typeFilters');
+    const yearSelect = document.getElementById('filterYear');
+    const monthSelect = document.getElementById('filterMonth');
+
+    document.addEventListener('DOMContentLoaded', () => {
+      setupOffcanvas();
+      setupTypeFilterInteractions();
+      setupSelectFilters();
+      loadTimeline();
     });
-  }
 
-  document.getElementById('filterYear').addEventListener('change', e => {
-    filters.year = e.target.value;
-    applyFilters();
-  });
-  document.getElementById('filterMonth').addEventListener('change', e => {
-    filters.month = e.target.value;
-    applyFilters();
-  });
-
-  // Toggle expand/collapse on click
-  document.querySelectorAll('.timeline-event').forEach(eventCol => {
-    eventCol.addEventListener('click', e => {
-      const row = eventCol.closest('.timeline-row');
-      document.querySelectorAll('.timeline-row.active').forEach(openRow => {
-        if (openRow !== row) openRow.classList.remove('active');
-      });
-      row.classList.toggle('active');
-    });
-  });
-</script>
-<script>
-  document.addEventListener("DOMContentLoaded", () => {
-    const offcanvas = document.getElementById('offcanvasNav');
-    const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
-
-    if (offcanvas && toggler) {
-      offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
-      offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
+    function loadTimeline() {
+      showLoadingMessage();
+      HarvardData.loadEvents()
+        .then((data) => {
+          events = HarvardData.sortEvents(data, 'desc');
+          renderFilters(events);
+          renderTimeline(events);
+          applyFilters();
+        })
+        .catch((error) => {
+          console.error(error);
+          showErrorMessage('Unable to load timeline data right now. Please try again later.');
+        });
     }
-  });
+
+    function showLoadingMessage() {
+      timelineEl.innerHTML = '<p class="text-muted">Loading timeline…</p>';
+      emptyStateEl.classList.add('d-none');
+      errorEl.classList.add('d-none');
+      errorEl.textContent = '';
+    }
+
+    function renderFilters(data) {
+      renderYearOptions(data);
+      renderMonthOptions(data);
+      renderTypeFilters(data);
+    }
+
+    function renderYearOptions(data) {
+      const uniqueYears = Array.from(new Set(data.map((event) => event.year).filter(Boolean))).sort((a, b) => b.localeCompare(a));
+      const previousSelection = filters.year;
+      yearSelect.innerHTML = '<option value="">All Years</option>' + uniqueYears.map((year) => `<option value="${year}">${year}</option>`).join('');
+      if (previousSelection && uniqueYears.includes(previousSelection)) {
+        yearSelect.value = previousSelection;
+      } else {
+        filters.year = '';
+        yearSelect.value = '';
+      }
+      updateMonthOptionsForYear(filters.year);
+    }
+
+    function renderMonthOptions(data) {
+      const monthMap = new Map();
+      data.forEach((event) => {
+        if (event.monthNumber && event.monthName && !monthMap.has(event.monthNumber)) {
+          monthMap.set(event.monthNumber, event.monthName);
+        }
+      });
+      populateMonthSelect(monthMap);
+    }
+
+    function updateMonthOptionsForYear(selectedYear) {
+      const monthMap = new Map();
+      events.forEach((event) => {
+        if (selectedYear && event.year !== selectedYear) {
+          return;
+        }
+        if (event.monthNumber && event.monthName && !monthMap.has(event.monthNumber)) {
+          monthMap.set(event.monthNumber, event.monthName);
+        }
+      });
+      const previousMonth = filters.month;
+      populateMonthSelect(monthMap);
+      if (previousMonth && monthMap.has(previousMonth)) {
+        monthSelect.value = previousMonth;
+      } else {
+        filters.month = '';
+        monthSelect.value = '';
+      }
+    }
+
+    function populateMonthSelect(monthMap) {
+      const sortedMonths = Array.from(monthMap.entries()).sort((a, b) => Number(a[0]) - Number(b[0]));
+      monthSelect.innerHTML = '<option value="">All Months</option>' + sortedMonths.map(([value, label]) => `<option value="${value}">${label}</option>`).join('');
+    }
+
+    function renderTypeFilters(data) {
+      const typeMap = new Map();
+      data.forEach((event) => {
+        if (!typeMap.has(event.typeSlug)) {
+          typeMap.set(event.typeSlug, event.type);
+        }
+      });
+      if (filters.type && !typeMap.has(filters.type)) {
+        filters.type = '';
+      }
+      typeFilterList.innerHTML = '';
+      typeFilterList.appendChild(createTypeFilterItem('All categories', '', filters.type === ''));
+      Array.from(typeMap.entries())
+        .sort((a, b) => a[1].localeCompare(b[1]))
+        .forEach(([slug, label]) => {
+          typeFilterList.appendChild(createTypeFilterItem(label, slug, filters.type === slug));
+        });
+    }
+
+    function createTypeFilterItem(label, value, isActive) {
+      const item = document.createElement('li');
+      item.className = 'list-group-item list-group-item-action text-nowrap';
+      item.dataset.type = value;
+      item.setAttribute('role', 'button');
+      item.setAttribute('tabindex', '0');
+      if (isActive) {
+        item.classList.add('active');
+      }
+      item.textContent = label;
+      return item;
+    }
+
+    function renderTimeline(data) {
+      timelineEl.innerHTML = '';
+      const fragment = document.createDocumentFragment();
+      data.forEach((event) => {
+        fragment.appendChild(createTimelineRow(event));
+      });
+      timelineEl.appendChild(fragment);
+      setupTimelineInteractions();
+    }
+
+    function createTimelineRow(event) {
+      const row = document.createElement('div');
+      row.className = 'row timeline-row';
+      row.dataset.year = event.year || '';
+      row.dataset.month = event.monthNumber || '';
+      row.dataset.type = event.typeSlug || '';
+
+      const monthLabel = event.monthName || '';
+      const dayLabel = event.day || '';
+      const yearLabel = event.year || '';
+      const title = escapeHtml(event.title);
+      const preview = truncateText(event.description, 120);
+
+      row.innerHTML = `
+        <div class="col-2 fw-bold">${escapeHtml(yearLabel)}</div>
+        <div class="col-2 text-center">
+          <div>${escapeHtml(monthLabel)}</div>
+          <div class="fw-bold fs-5">${escapeHtml(dayLabel)}</div>
+        </div>
+        <div class="col-1 timeline-col">
+          <div class="timeline-line"></div>
+          <div class="timeline-dot"></div>
+        </div>
+        <div class="col-7 timeline-event" role="button" tabindex="0">
+          <div class="timeline-preview">
+            <h2 class="h5 mb-1">${title}</h2>
+            <p class="mb-0">${escapeHtml(preview)}</p>
+          </div>
+          <div class="card timeline-card">
+            <div class="card-body">
+              <div class="card-text-area">
+                <h2 class="h5">${title}</h2>
+                <p>${escapeHtml(event.description)}</p>
+                ${buildMetadataMarkup(event)}
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+      return row;
+    }
+
+    function buildMetadataMarkup(event) {
+      const details = [];
+      if (event.type) {
+        details.push(`<p class="mb-2"><strong>Category:</strong> ${escapeHtml(event.type)}</p>`);
+      }
+      if (event.displayDate) {
+        details.push(`<p class="mb-2"><strong>Date:</strong> ${escapeHtml(event.displayDate)}</p>`);
+      }
+      if (event.source) {
+        details.push(`<p class="mb-0"><strong>Source:</strong> ${formatSource(event)}</p>`);
+      }
+      return details.join('');
+    }
+
+    function formatSource(event) {
+      if (event.sourceLink) {
+        return `<a href="${event.sourceLink}" target="_blank" rel="noopener">${escapeHtml(getSourceLabel(event.source))}</a>`;
+      }
+      return escapeHtml(event.source);
+    }
+
+    function getSourceLabel(value) {
+      try {
+        const url = new URL(value);
+        return url.hostname.replace(/^www\./, '');
+      } catch (error) {
+        return value.length > 60 ? `${value.slice(0, 57)}…` : value;
+      }
+    }
+
+    function setupTimelineInteractions() {
+      timelineEl.querySelectorAll('.timeline-event').forEach((eventCol) => {
+        eventCol.addEventListener('click', () => toggleRow(eventCol));
+        eventCol.addEventListener('keydown', (event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            toggleRow(eventCol);
+          }
+        });
+      });
+    }
+
+    function toggleRow(eventCol) {
+      const row = eventCol.closest('.timeline-row');
+      const isActive = row.classList.contains('active');
+      timelineEl.querySelectorAll('.timeline-row.active').forEach((openRow) => openRow.classList.remove('active'));
+      if (!isActive) {
+        row.classList.add('active');
+      }
+    }
+
+    function setupTypeFilterInteractions() {
+      typeFilterList.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-type]');
+        if (target) {
+          updateTypeFilter(target.dataset.type || '');
+        }
+      });
+      typeFilterList.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          const target = event.target.closest('[data-type]');
+          if (target) {
+            event.preventDefault();
+            updateTypeFilter(target.dataset.type || '');
+          }
+        }
+      });
+    }
+
+    function updateTypeFilter(value) {
+      filters.type = value;
+      typeFilterList.querySelectorAll('[data-type]').forEach((item) => {
+        item.classList.toggle('active', (item.dataset.type || '') === value);
+      });
+      applyFilters();
+    }
+
+    function setupSelectFilters() {
+      yearSelect.addEventListener('change', (event) => {
+        filters.year = event.target.value;
+        updateMonthOptionsForYear(filters.year);
+        applyFilters();
+      });
+      monthSelect.addEventListener('change', (event) => {
+        filters.month = event.target.value;
+        applyFilters();
+      });
+    }
+
+    function applyFilters() {
+      errorEl.classList.add('d-none');
+      errorEl.textContent = '';
+      let visibleCount = 0;
+      timelineEl.querySelectorAll('.timeline-row').forEach((row) => {
+        const matches =
+          (!filters.year || row.dataset.year === filters.year) &&
+          (!filters.month || row.dataset.month === filters.month) &&
+          (!filters.type || row.dataset.type === filters.type);
+        row.style.display = matches ? '' : 'none';
+        if (matches) {
+          visibleCount += 1;
+        }
+      });
+      emptyStateEl.classList.toggle('d-none', visibleCount > 0);
+    }
+
+    function showErrorMessage(message) {
+      timelineEl.innerHTML = '';
+      emptyStateEl.classList.add('d-none');
+      errorEl.textContent = message;
+      errorEl.classList.remove('d-none');
+    }
+
+    function truncateText(value, maxLength) {
+      const text = value || '';
+      if (text.length <= maxLength) {
+        return text;
+      }
+      return `${text.slice(0, maxLength - 1)}…`;
+    }
+
+    function escapeHtml(value) {
+      return (value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function setupOffcanvas() {
+      const offcanvas = document.getElementById('offcanvasNav');
+      const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
+      if (offcanvas && toggler) {
+        offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
+        offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
+      }
+    }
+  })();
 </script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/Tracker.html
+++ b/Harvard/Tracker.html
@@ -75,10 +75,12 @@
     /* Rotate chevron on expand */
     .accordion-toggle[aria-expanded="true"] .bi { transform: rotate(180deg); }
 
-    /* Status background colors (collapsed rows) */
-    .status-resolved { background-color: #D1E7E0; }
-    .status-progress { background-color: #F3EED9; }
-    .status-not-taken { background-color: #E19896; }
+    /* Category background colors (collapsed rows) */
+    .status-official { background-color: #D1E7E0; }
+    .status-campus { background-color: #F3EED9; }
+    .status-world { background-color: #E19896; }
+    .status-response { background-color: #E7D8F5; }
+    .status-default { background-color: #E9ECEF; }
 
     /* Expanded row border colors */
     .accordion-body {
@@ -88,9 +90,11 @@
     }
     tr > td[colspan] { padding: 0 !important; }
 
-    .status-resolved + tr .accordion-body { border-color: #D1E7E0; }
-    .status-progress + tr .accordion-body { border-color: #F3EED9; }
-    .status-not-taken + tr .accordion-body { border-color: #E19896; }
+    .status-official + tr .accordion-body { border-color: #D1E7E0; }
+    .status-campus + tr .accordion-body { border-color: #F3EED9; }
+    .status-world + tr .accordion-body { border-color: #E19896; }
+    .status-response + tr .accordion-body { border-color: #E7D8F5; }
+    .status-default + tr .accordion-body { border-color: #E9ECEF; }
   </style>
 </head>
 <body>
@@ -126,14 +130,14 @@
 
   <!-- Tracker -->
   <div class="container my-5">
-    <h2>Recommendations Tracker</h2>
+    <h2>Event Tracker</h2>
     <div class="table-responsive">
       <table class="table" id="accordionData">
         <thead>
           <tr>
             <th scope="col">Date</th>
-            <th scope="col">Recommendation</th>
-            <th scope="col">Status</th>
+            <th scope="col">Event / Info</th>
+            <th scope="col">Category</th>
             <th scope="col" class="text-end">Expand</th>
           </tr>
         </thead>
@@ -152,64 +156,145 @@
     <a href="#" class="text-white mx-2"><i class="bi bi-linkedin"></i></a>
   </footer>
 
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+  <script src="js/data-utils.js"></script>
   <script>
-    async function loadData() {
-      // Fake test data (replace with fetch)
-      const data = [
-        { date: "April 1, 2023", title: "Recommendation 1", status: "Resolved", organization: "Org A", type: "Type A", description: "Fixed issue", timestamp: "2023-04-01" },
-        { date: "April 2, 2023", title: "Recommendation 2", status: "In Progress", organization: "Org B", type: "Type B", description: "Still working", timestamp: "2023-04-02" },
-        { date: "April 3, 2023", title: "Recommendation 3", status: "Not Taken", organization: "Org C", type: "Type C", description: "Not acted upon", timestamp: "2023-04-03" }
-      ];
+    (function () {
+      const STATUS_CLASS_MAP = {
+        'harvard-official-statement': 'status-official',
+        'harvard-campus-event': 'status-campus',
+        'world-event': 'status-world',
+        'jewish-communal-response': 'status-response'
+      };
+      const DEFAULT_STATUS_CLASS = 'status-default';
 
-      const container = document.querySelector("#accordionData tbody");
-      container.innerHTML = "";
+      const tableBody = document.querySelector('#accordionData tbody');
 
-      data.forEach((row, i) => {
-        let statusClass = "";
-        if (row.status === "Resolved") statusClass = "status-resolved";
-        else if (row.status === "In Progress") statusClass = "status-progress";
-        else if (row.status === "Not Taken") statusClass = "status-not-taken";
+      document.addEventListener('DOMContentLoaded', () => {
+        setupOffcanvas();
+        setupKeyboardSupport();
+        loadTracker();
+      });
 
-        container.innerHTML += `
-          <tr class="accordion-toggle collapsed ${statusClass}"
-              role="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#collapse${i}"
-              aria-expanded="false"
-              aria-controls="collapse${i}">
-            <td>${row.date}</td>
-            <td>${row.title}</td>
-            <td>${row.status}</td>
+      function loadTracker() {
+        renderMessageRow('Loading tracker…');
+        HarvardData.loadEvents()
+          .then((data) => HarvardData.sortEvents(data, 'desc'))
+          .then((events) => {
+            if (!events.length) {
+              renderMessageRow('No records available yet.');
+              return;
+            }
+            renderRows(events);
+          })
+          .catch((error) => {
+            console.error(error);
+            renderMessageRow('Unable to load tracker data right now.');
+          });
+      }
+
+      function renderRows(events) {
+        tableBody.innerHTML = '';
+        events.forEach((event, index) => {
+          const collapseId = `trackerCollapse${index}`;
+          const statusClass = STATUS_CLASS_MAP[event.typeSlug] || DEFAULT_STATUS_CLASS;
+
+          const summaryRow = document.createElement('tr');
+          summaryRow.className = `accordion-toggle collapsed ${statusClass}`;
+          summaryRow.setAttribute('role', 'button');
+          summaryRow.setAttribute('tabindex', '0');
+          summaryRow.setAttribute('data-bs-toggle', 'collapse');
+          summaryRow.setAttribute('data-bs-target', `#${collapseId}`);
+          summaryRow.setAttribute('aria-expanded', 'false');
+          summaryRow.setAttribute('aria-controls', collapseId);
+          summaryRow.innerHTML = `
+            <td>${escapeHtml(event.displayDate)}</td>
+            <td>${escapeHtml(event.title)}</td>
+            <td>${escapeHtml(event.type)}</td>
             <td class="expand-button">
               <span class="toggle-icon"><i class="bi bi-chevron-down"></i></span>
             </td>
-          </tr>
-          <tr>
+          `;
+          tableBody.appendChild(summaryRow);
+
+          const detailRow = document.createElement('tr');
+          detailRow.innerHTML = `
             <td colspan="4">
-              <div id="collapse${i}" class="collapse accordion-body p-3" data-bs-parent="#accordionData">
-                <div class="row"><div class="col-2">Organization</div><div class="col-6">${row.organization}</div></div>
-                <div class="row"><div class="col-2">Type</div><div class="col-6">${row.type}</div></div>
-                <div class="row"><div class="col-2">Description</div><div class="col-6">${row.description}</div></div>
-                <small><em>Submitted: ${row.timestamp}</em></small>
+              <div id="${collapseId}" class="collapse accordion-body p-3" data-bs-parent="#accordionData">
+                <div class="mb-3">
+                  <strong>Summary</strong>
+                  <p class="mb-1">${escapeHtml(event.description)}</p>
+                </div>
+                <div class="row g-2">
+                  <div class="col-sm-3 fw-semibold">Category</div>
+                  <div class="col-sm-9">${escapeHtml(event.type)}</div>
+                </div>
+                <div class="row g-2">
+                  <div class="col-sm-3 fw-semibold">Source</div>
+                  <div class="col-sm-9">${formatSource(event)}</div>
+                </div>
+                <div class="row g-2">
+                  <div class="col-sm-3 fw-semibold">Recorded</div>
+                  <div class="col-sm-9">${escapeHtml(event.displayDate)}</div>
+                </div>
               </div>
             </td>
-          </tr>`;
-      });
-    }
-
-    document.addEventListener("DOMContentLoaded", () => {
-      // Load table
-      loadData();
-
-      // Hook the offcanvas events to flip the toggler icon
-      const offcanvas = document.getElementById('offcanvasNav');
-      const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
-
-      if (offcanvas && toggler) {
-        offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
-        offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
+          `;
+          tableBody.appendChild(detailRow);
+        });
       }
-    });
+
+      function renderMessageRow(message) {
+        tableBody.innerHTML = `<tr><td colspan="4" class="text-center text-muted py-4">${escapeHtml(message)}</td></tr>`;
+      }
+
+      function setupKeyboardSupport() {
+        tableBody.addEventListener('keydown', (event) => {
+          if ((event.key === 'Enter' || event.key === ' ') && event.target.classList.contains('accordion-toggle')) {
+            event.preventDefault();
+            event.target.click();
+          }
+        });
+      }
+
+      function formatSource(event) {
+        if (event.sourceLink) {
+          return `<a href="${event.sourceLink}" target="_blank" rel="noopener">${escapeHtml(getSourceLabel(event.source))}</a>`;
+        }
+        if (event.source) {
+          return escapeHtml(event.source);
+        }
+        return '<span class="text-muted">Not provided</span>';
+      }
+
+      function getSourceLabel(value) {
+        try {
+          const url = new URL(value);
+          return url.hostname.replace(/^www\./, '');
+        } catch (error) {
+          return value.length > 60 ? `${value.slice(0, 57)}…` : value;
+        }
+      }
+
+      function escapeHtml(value) {
+        return (value || '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#39;');
+      }
+
+      function setupOffcanvas() {
+        const offcanvas = document.getElementById('offcanvasNav');
+        const toggler = document.querySelector('[data-bs-toggle="offcanvas"][data-bs-target="#offcanvasNav"]');
+
+        if (offcanvas && toggler) {
+          offcanvas.addEventListener('show.bs.offcanvas', () => toggler.classList.add('is-open'));
+          offcanvas.addEventListener('hide.bs.offcanvas', () => toggler.classList.remove('is-open'));
+        }
+      }
+    })();
   </script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/Harvard/js/data-utils.js
+++ b/Harvard/js/data-utils.js
@@ -1,0 +1,238 @@
+(function (global) {
+  const CSV_PATH = 'Content Tracker _ Timeline - Timeline of Events.csv';
+  const MONTH_NAMES = [
+    'January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December'
+  ];
+
+  function loadEvents() {
+    return new Promise((resolve, reject) => {
+      if (typeof Papa === 'undefined') {
+        reject(new Error('Papa Parse is required to load CSV data.'));
+        return;
+      }
+
+      Papa.parse(CSV_PATH, {
+        download: true,
+        header: true,
+        skipEmptyLines: 'greedy',
+        transformHeader(header) {
+          const trimmed = (header || '').trim();
+          return trimmed === '' ? 'Year' : trimmed;
+        },
+        complete(results) {
+          try {
+            const events = transformRows(results.data || []);
+            resolve(events);
+          } catch (error) {
+            reject(error);
+          }
+        },
+        error(error) {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  function transformRows(rows) {
+    const events = [];
+    let lastYear = '';
+    let lastDate = '';
+    let lastSortKey = Number.NEGATIVE_INFINITY;
+
+    rows.forEach((rawRow) => {
+      const eventInfo = (rawRow['Event / Info'] || '').trim();
+      if (!eventInfo) {
+        return;
+      }
+
+      let year = normalizeYear(rawRow.Year);
+      if (year) {
+        lastYear = year;
+      } else if (lastYear) {
+        year = lastYear;
+      }
+
+      let rawDate = (rawRow.Date || '').toString().trim();
+      if (rawDate) {
+        lastDate = rawDate;
+      } else if (lastDate) {
+        rawDate = lastDate;
+      }
+
+      const parsedDate = parseDate(rawDate, year);
+      if (parsedDate.year) {
+        year = parsedDate.year;
+        lastYear = year;
+      }
+
+      let sortKey = parsedDate.sortKey;
+      if (!Number.isFinite(sortKey) || sortKey === Number.NEGATIVE_INFINITY) {
+        sortKey = year ? new Date(Number(year), 0, 1).getTime() : lastSortKey;
+      }
+      if (Number.isFinite(sortKey)) {
+        lastSortKey = sortKey;
+      }
+
+      const sourceRaw = (rawRow.Source || '').trim();
+      const typeRaw = (rawRow.Type || '').trim();
+      const type = typeRaw || 'Uncategorized';
+      const typeSlug = slugify(type);
+
+      events.push({
+        title: eventInfo,
+        description: eventInfo,
+        year: year || '',
+        monthName: parsedDate.monthName,
+        monthNumber: parsedDate.monthNumber,
+        day: parsedDate.day,
+        rawDate: rawDate,
+        displayDate: buildDisplayDate(parsedDate, year, rawDate),
+        type,
+        typeSlug,
+        source: sourceRaw,
+        sourceLink: isLikelyUrl(sourceRaw) ? sourceRaw : '',
+        sortKey
+      });
+    });
+
+    return events;
+  }
+
+  function buildDisplayDate(parsedDate, year, rawDate) {
+    if (parsedDate.dateLabel) {
+      return parsedDate.dateLabel;
+    }
+    if (rawDate) {
+      return rawDate;
+    }
+    return year || 'Date TBD';
+  }
+
+  function parseDate(dateStr, fallbackYear) {
+    const cleaned = (dateStr || '').replace(/\?/g, '').trim();
+    if (!cleaned) {
+      const year = normalizeYear(fallbackYear);
+      return {
+        monthNumber: '',
+        monthName: '',
+        day: '',
+        year,
+        dateLabel: year || '',
+        sortKey: year ? new Date(Number(year), 0, 1).getTime() : Number.NEGATIVE_INFINITY
+      };
+    }
+
+    const parts = cleaned.split('/');
+    let [monthPart = '', dayPart = '', yearPart = ''] = parts;
+
+    monthPart = monthPart.replace(/\D/g, '');
+    dayPart = dayPart.replace(/\D/g, '');
+    yearPart = yearPart.replace(/\D/g, '');
+
+    const monthNumber = monthPart ? monthPart.padStart(2, '0') : '';
+    const monthIndex = monthNumber ? Number(monthNumber) - 1 : NaN;
+    const monthName = Number.isInteger(monthIndex) && MONTH_NAMES[monthIndex] ? MONTH_NAMES[monthIndex] : '';
+
+    const day = dayPart ? String(parseInt(dayPart, 10)) : '';
+    const year = normalizeYear(yearPart || fallbackYear);
+
+    const labelParts = [];
+    if (monthName) {
+      labelParts.push(monthName);
+    }
+    if (day) {
+      labelParts.push(day);
+    }
+    if (year) {
+      labelParts.push(year);
+    }
+
+    let sortKey = Number.NEGATIVE_INFINITY;
+    if (year) {
+      const monthForDate = monthNumber ? Number(monthNumber) - 1 : 0;
+      const dayForDate = day ? Number(day) : 1;
+      sortKey = new Date(Number(year), monthForDate, dayForDate).getTime();
+    }
+
+    return {
+      monthNumber,
+      monthName,
+      day,
+      year,
+      dateLabel: labelParts.join(' ').trim(),
+      sortKey
+    };
+  }
+
+  function normalizeYear(value) {
+    if (value === undefined || value === null) {
+      return '';
+    }
+
+    const digits = value.toString().replace(/\D/g, '');
+    if (!digits) {
+      return '';
+    }
+
+    if (digits.length === 4) {
+      return digits;
+    }
+
+    if (digits.length === 2) {
+      const numeric = Number(digits);
+      const century = numeric < 50 ? '20' : '19';
+      return century + digits.padStart(2, '0');
+    }
+
+    if (digits.length === 3) {
+      return `2${digits.padStart(3, '0')}`;
+    }
+
+    if (digits.length === 1) {
+      return `200${digits}`;
+    }
+
+    return digits;
+  }
+
+  function slugify(value) {
+    const base = (value || '').toString().trim();
+    if (!base) {
+      return 'uncategorized';
+    }
+    return (
+      base
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'uncategorized'
+    );
+  }
+
+  function isLikelyUrl(value) {
+    return /^https?:\/\//i.test(value || '');
+  }
+
+  function sortEvents(events, direction = 'desc') {
+    const factor = direction === 'asc' ? 1 : -1;
+    return [...events].sort((a, b) => {
+      const aKey = Number.isFinite(a.sortKey) ? a.sortKey : Number.NEGATIVE_INFINITY;
+      const bKey = Number.isFinite(b.sortKey) ? b.sortKey : Number.NEGATIVE_INFINITY;
+
+      if (aKey === bKey) {
+        return factor * a.title.localeCompare(b.title);
+      }
+
+      return factor * (aKey - bKey);
+    });
+  }
+
+  global.HarvardData = {
+    loadEvents,
+    sortEvents,
+    slugify,
+    isLikelyUrl,
+    MONTH_NAMES
+  };
+})(window);


### PR DESCRIPTION
## Summary
- add a shared data utility that loads and normalises the timeline CSV
- render the timeline dynamically with CSV-backed filters and error handling
- populate the tracker table from the same CSV with category styling and accessibility tweaks

## Testing
- node --check Harvard/js/data-utils.js

------
https://chatgpt.com/codex/tasks/task_e_68d1e2cee9f08323b73a22006abce189